### PR TITLE
Fix cons patterns

### DIFF
--- a/parse/Parser.sml
+++ b/parse/Parser.sml
@@ -535,7 +535,7 @@ struct
               (true, consume_patInfix infdict pat (tok i) (i+1))
 
             else if
-r             appOkay restriction
+              appOkay restriction
               andalso Ast.Pat.okayForConPat pat
               andalso check Token.isAtPatStartToken at i
             then

--- a/parse/Parser.sml
+++ b/parse/Parser.sml
@@ -519,13 +519,6 @@ struct
         let
           val (again, (i, pat)) =
             if
-              appOkay restriction
-              andalso Ast.Pat.okayForConPat pat
-              andalso check Token.isAtPatStartToken at i
-            then
-              (true, consume_patCon infdict (Ast.Pat.unpackForConPat pat) i)
-
-            else if
               (** Annoying edge case with '='... we can use it in an infix
                 * expression as an equality predicate, but it is NEVER valid as
                 * an infix constructor, because SML forbids rebinding '=' in
@@ -542,6 +535,14 @@ struct
               (true, consume_patInfix infdict pat (tok i) (i+1))
 
             else if
+r             appOkay restriction
+              andalso Ast.Pat.okayForConPat pat
+              andalso check Token.isAtPatStartToken at i
+            then
+              (true, consume_patCon infdict (Ast.Pat.unpackForConPat pat) i)
+
+            else if
+
               isReserved Token.Colon at i
               andalso anyOkay restriction
             then


### PR DESCRIPTION
+ Problem: Currently, the program:
```sml
fun foo (x::xs) = x
```
is being rejected. See the following:
```
λ ~/P/parse-sml on fix-cons-patterns  ./main test/succeed/functions.sml                                                      16:44:23
fun foo (x::xs) = x

Lexing succeeded.
Parsing...

-- PARSE ERROR -------------------------------------- test/succeed/functions.sml

Infix identifier not prefaced by 'op'

1| fun foo (x::xs) = x
             ^^
```
This appears to be due to the `if` branch for pattern constructors coming before the branch for infix constructors. Infix constructors fall into the requirements for the first case, meaning that we never reach the infix branch. This leads to an error about infix identifiers, since now "op" is expected.

+ Solution: Swap the two branches. Seems that all the tests still pass, and now we get:
```
λ ~/P/parse-sml on fix-cons-patterns  ./main test/succeed/functions.sml                                                      16:50:52
fun foo (x::xs) = x

Lexing succeeded.
Parsing...

fun foo ((x :: xs)) = x

Parsing succeeded.
```
as desired.
