### PR TITLE
Add function branches

### DIFF
--- a/parse/Parser.sml
+++ b/parse/Parser.sml
@@ -959,11 +959,12 @@ struct
         *)
       and consume_decFun (i, infdict) =
         let
-          (** [op]vid atpat .... atpat [: ty] = exp *)
+          (** [op]vid atpat .... atpat [: ty] = exp [| ...] *)
           fun parseElem i =
             let
               val (_, {vid = func_name, ...}) = consume_opvid infdict i
 
+              (** [op]vid atpat ... atpat [: ty] = exp *)
               fun parseBranch vid i =
                 let
                   val (i, {opp, vid}) = consume_opvid infdict i

--- a/parse/Parser.sml
+++ b/parse/Parser.sml
@@ -535,7 +535,7 @@ struct
               (true, consume_patInfix infdict pat (tok i) (i+1))
 
             else if
-r             appOkay restriction
+              appOkay restriction
               andalso Ast.Pat.okayForConPat pat
               andalso check Token.isAtPatStartToken at i
             then

--- a/parse/Parser.sml
+++ b/parse/Parser.sml
@@ -519,13 +519,6 @@ struct
         let
           val (again, (i, pat)) =
             if
-              appOkay restriction
-              andalso Ast.Pat.okayForConPat pat
-              andalso check Token.isAtPatStartToken at i
-            then
-              (true, consume_patCon infdict (Ast.Pat.unpackForConPat pat) i)
-
-            else if
               (** Annoying edge case with '='... we can use it in an infix
                 * expression as an equality predicate, but it is NEVER valid as
                 * an infix constructor, because SML forbids rebinding '=' in
@@ -542,6 +535,14 @@ struct
               (true, consume_patInfix infdict pat (tok i) (i+1))
 
             else if
+r             appOkay restriction
+              andalso Ast.Pat.okayForConPat pat
+              andalso check Token.isAtPatStartToken at i
+            then
+              (true, consume_patCon infdict (Ast.Pat.unpackForConPat pat) i)
+
+            else if
+
               isReserved Token.Colon at i
               andalso anyOkay restriction
             then

--- a/test/fail/bad-functions.sml
+++ b/test/fail/bad-functions.sml
@@ -1,0 +1,2 @@
+fun 'a fact = 0
+  | fac = n * fact (n-1)

--- a/test/succeed/functions.sml
+++ b/test/succeed/functions.sml
@@ -1,0 +1,13 @@
+fun 'a op fact 0 = 1
+  | op fact n = n * fact (n-1)
+
+fun ('a, 'b) bar 0 = 2
+  | op bar n = n
+and op baz (SOME true) = []
+  | baz (SOME false) = [2, 3]
+  | baz NONE = [3, 1, 4]
+and bear [] = ()
+and bees "hi" = "there"
+
+fun ('a, 'b, 'c) op foo 0 (SOME x) (x, y, z) {bob, harper} [2] _ true () = 3
+  | foo n NONE (a, b, c) {bob, harper = 3} (2::3::[]) "hi" _ () = 5


### PR DESCRIPTION
+ Problem: We cannot currently parse multi-clause functions. For instance, consider the function:
```sml
fun fact 0 = 1
  | fact n = n * fact (n-1)
```
Attempting to parse this program produces:
```
λ ~/P/parse-sml on main ◦ ./main test.sml                                                            17:41:48
fun fact 0 = 1
  | fact n = n * fact (n-1)

Lexing succeeded.
Parsing...

-- PARSE ERROR -------------------------------------------------------- test.sml

Unexpected token.

2|   | fact n = n * fact (n-1)
     ^
Invalid start of top-level declaration!
```
+ Solution: We have added support for multi-clausal function definitions. Also, there is a check that the names of each clause in the function must be the same, and it will throw an error if it does not (with the expected name). There are some tests verifying that it works as expected.

I don't know if this is entirely idiomatic with your style, but I tried to be close.

Potential future work: Add an error when any mutually recursive functions have the same name.