### PR TITLE
added support for mutually recursive types

### DIFF
--- a/parse/Parser.sml
+++ b/parse/Parser.sml
@@ -1097,10 +1097,8 @@ struct
         end
 
 
-      (** type tyvars tycon = ty
+      (** type tyvars tycon = ty [and tyvars tycon = ty ...]
         *     ^
-        *
-        * TODO: implement possible [and type tyvars tycon = ty and ...]
         *)
       and consume_decType (i, infdict) =
         let

--- a/parse/Parser.sml
+++ b/parse/Parser.sml
@@ -1105,29 +1105,36 @@ struct
       and consume_decType (i, infdict) =
         let
           val typee = tok (i-1)
-          val (i, tyvars) = parse_tyvars i
-          val (i, tycon) =
-            if check Token.isTyCon at i then
-              (i+1, tok i)
-            else
-              error
-                { pos = Token.getSource (tok i)
-                , what = "Unexpected token. Invalid type constructor."
-                , explain = NONE
-                }
 
-          val (i, eq) = parse_reserved Token.Equal i
-          val (i, ty) = consume_ty {permitArrows=true} i
+          fun parseElem i =
+            let
+              val (i, tyvars) = parse_tyvars i
+              val (i, tycon) =
+                if check Token.isTyCon at i then
+                  (i+1, tok i)
+                else
+                  error
+                    { pos = Token.getSource (tok i)
+                    , what = "Unexpected token. Invalid type constructor."
+                    , explain = NONE
+                    }
 
-          val typbind =
-            { delims = Seq.empty ()
-            , elems = Seq.singleton
-                { tyvars = tyvars
+              val (i, eq) = parse_reserved Token.Equal i
+              val (i, ty) = consume_ty {permitArrows=true} i
+            in
+              ( i
+              , { tyvars = tyvars
                 , tycon = tycon
                 , eq = eq
                 , ty = ty
                 }
-            }
+              )
+            end
+
+          val (i, typbind) =
+            parse_oneOrMoreDelimitedByReserved
+              {parseElem = parseElem, delim = Token.And}
+              i
         in
           ( (i, infdict)
           , Ast.Exp.DecType

--- a/test/succeed/mutually-recursive-types.sml
+++ b/test/succeed/mutually-recursive-types.sml
@@ -1,0 +1,3 @@
+type 'a foo = int
+and 'b bar = 'b option
+and ('c, 'd) baz = 'c * 'd -> int list


### PR DESCRIPTION
+ Problem: Currently, we cannot parse programs with mutually recursive types. Consider the program:
```sml
type 'a foo = int
and 'b bar = 'b option
and ('c, 'd) baz = 'c * 'd -> int list
```
This currently results in the following:
```
λ ~/P/parse-sml on main ◦ ./main test/succeed/mutually-recursive-types.sml
type 'a foo = int
and 'b bar = 'b option
and ('c, 'd) baz = 'c * 'd -> int list

Lexing succeeded.
Parsing...

-- PARSE ERROR --------- test/succeed/mutually-recursive-types.sml

Unexpected token.

2| and 'b bar = 'b option
   ^^^
Invalid start of top-level declaration!
```

+ Solution: Added in support for mutually recursive types. Now, we get:
```
λ ~/P/parse-sml on main ◦ ./main test/succeed/mutually-recursive-types.sml
type 'a foo = int
and 'b bar = 'b option
and ('c, 'd) baz = 'c * 'd -> int list

Lexing succeeded.
Parsing...

type 'a foo = int

Parsing succeeded.
```

Future work: Could add in an error when there two mutually recursive types share the same name.

