### PR TITLE
added support for local decs, plus pretty printing

### DIFF
--- a/parse/Parser.sml
+++ b/parse/Parser.sml
@@ -875,6 +875,8 @@ struct
           consume_decFun (i+1, infdict)
         else if isReserved Token.Exception at i then
           consume_decException (tok i) (i+1, infdict)
+        else if isReserved Token.Local at i then
+          consume_decLocal (i+1, infdict)
         else
           nyi "consume_oneDec" i
 
@@ -1015,6 +1017,30 @@ struct
               { funn = funn
               , tyvars = tyvars
               , fvalbind = fvalbind
+              }
+          )
+        end
+
+      (** local dec1 in dec2 end
+        *      ^
+        *)
+      and consume_decLocal (i, infdict) =
+        let
+          val original_infdict = infdict
+
+          val locall = tok (i-1)
+          val (i, infdict, dec1) = consume_dec infdict i
+          val (i, inn) = parse_reserved Token.In i
+          val (i, _, dec2) = consume_dec infdict i
+          val (i, endd) = parse_reserved Token.End i
+        in
+          ( (i, original_infdict)
+          , Ast.Exp.DecLocal
+              { locall = locall
+              , left_dec = dec1
+              , inn = inn
+              , right_dec = dec2
+              , endd = endd
               }
           )
         end

--- a/parse/PrettyPrintAst.sml
+++ b/parse/PrettyPrintAst.sml
@@ -270,6 +270,19 @@ struct
             Seq.iterate op$$ empty (Seq.mapIdx mk elems)
           end
 
+      | DecLocal {left_dec, right_dec, ...} =>
+          group (
+            text "local"
+            $$
+            (spaces 2 ++ showDec left_dec)
+            $$
+            text "in"
+            $$
+            (spaces 2 ++ showDec right_dec)
+            $$
+            text "end"
+          )
+
       | DecMultiple {elems, delims} =>
           let
             fun f i =

--- a/test/fail/bad-local-in-end-1.sml
+++ b/test/fail/bad-local-in-end-1.sml
@@ -1,0 +1,7 @@
+local
+  val x = 2
+  local
+    val y = 3
+in
+  val z = 4
+end

--- a/test/fail/bad-local-in-end-2.sml
+++ b/test/fail/bad-local-in-end-2.sml
@@ -1,0 +1,9 @@
+local
+  val x = 2
+  local
+    val y = 3
+  in
+    val q = 5
+in
+  val z = 4
+end

--- a/test/fail/bad-local-in-end-3.sml
+++ b/test/fail/bad-local-in-end-3.sml
@@ -1,0 +1,11 @@
+local
+  val x = 2
+  local
+    val y = 3
+  in
+    val q = 5
+  end
+  end
+in
+  val z = 4
+end

--- a/test/succeed/local-in-end.sml
+++ b/test/succeed/local-in-end.sml
@@ -1,0 +1,31 @@
+local
+  val x = 2
+  local
+    val y = 3
+    val z = 20
+  in
+    val res = y + z
+  end
+
+  local
+  in
+  end
+
+  local
+    val x = 3
+  in
+  end
+
+  local
+    val p = 2
+  in
+  end
+in
+  val q = 2
+  local
+    val m = 10
+  in
+    val p = 3
+  end
+  val out = res + x + p + q
+end


### PR DESCRIPTION
+ Problem: Currently, there is no support for local declarations. Consider the following program:
```sml
local
  val x = 2
in
  val y = x
end
```
This will cause the following error when parsed:
```
λ ~/P/parse-sml on main ◦ cat test.sml                    18:58:12
local
  val x = 2
in
  val y = x
end
λ ~/P/parse-sml on main ◦ ./main test.sml                 18:58:14
local
  val x = 2
in
  val y = x
end

Lexing succeeded.
Parsing...

-- ERROR: NOT YET IMPLEMENTED --------------------------- test.sml

Unexpected token.

1| local
   ^^^^^
(TODO: Sam: see Parser.parse.consume_oneDec)
```

+ Solution: This PR adds in support for local declarations, along with pretty printing for local declarations in the AST. There's also some tests.

Then, we correctly parse as:
```
λ ~/P/parse-sml on add-local-dec  ./main test.sml         18:59:45
local
  val x = 2
in
  val y = x
end

Lexing succeeded.
Parsing...

local val x = 2 in val y = x end

Parsing succeeded.
```

There's some weirdness still with infixity persisting beyond the `local in end`, but I think this is an existent issue - see #6.
