### PR TITLE
fixed pretty printing mutually recursive types

### DIFF
--- a/parse/PrettyPrintAst.sml
+++ b/parse/PrettyPrintAst.sml
@@ -187,20 +187,39 @@ struct
             Seq.iterate op$$ first (Seq.map mk (Seq.drop elems 1))
           end
 
-      | DecType {typee, typbind={elems, ...}} =>
+      | DecType {typbind={elems, ...}, ...} =>
           let
             val {tyvars, tycon, ty, ...} = Seq.nth elems 0
+
+            fun mk {tyvars, tycon, ty, ...} =
+              group (
+                separateWithSpaces
+                  [ SOME (text "and")
+                  , maybeShowSyntaxSeq tyvars (PD.text o Token.toString)
+                  , SOME (text (Token.toString tycon))
+                  , SOME (text "=")
+                  ]
+                $$
+                (spaces 2 ++ showTy ty)
+              )
+
+            val first =
+              let
+                val {tyvars, tycon, ty, ...} = Seq.nth elems 0
+              in
+                group (
+                  separateWithSpaces
+                    [ SOME (text "type")
+                    , maybeShowSyntaxSeq tyvars (PD.text o Token.toString)
+                    , SOME (text (Token.toString tycon))
+                    , SOME (text "=")
+                    ]
+                  $$
+                  (spaces 2 ++ showTy ty)
+                )
+              end
           in
-            group (
-              separateWithSpaces
-                [ SOME (text "type")
-                , maybeShowSyntaxSeq tyvars (PD.text o Token.toString)
-                , SOME (text (Token.toString tycon))
-                , SOME (text "=")
-                ]
-              $$
-              (spaces 2 ++ showTy ty)
-            )
+            Seq.iterate op$$ first (Seq.map mk (Seq.drop elems 1))
           end
 
       | DecInfix {precedence, elems, ...} =>


### PR DESCRIPTION
+ Problem: I forgot to add in support for pretty printing mutually recursive types (the current code only assumed that there was one). We used to get:
```
λ ~/P/parse-sml on add-datatype-dec ⨯ ./main test/succeed/mutually-recursive-types.sml            00:42:11
type 'a foo = int
and 'b bar = 'b option
and ('c, 'd) baz = 'c * 'd -> int list


type 'a foo = unit -> int bar
and 'a bar = unit -> (string, int array) baz
and ('a, 'b) baz = unit -> int list foo

Lexing succeeded.
Parsing...

type 'a foo = int
type 'a foo = unit -> int bar

Parsing succeeded.
```

+ Solution: Added that functionality in. Now it's:
```
λ ~/P/parse-sml on fix-pretty-printing-mutually-recursive-types ⨯ ./main test/succeed/mutually-recursive-types.sml                                                                                           00:48:49
type 'a foo = int
and 'b bar = 'b option
and ('c, 'd) baz = 'c * 'd -> int list


type 'a foo = unit -> int bar
and 'a bar = unit -> (string, int array) baz
and ('a, 'b) baz = unit -> int list foo

Lexing succeeded.
Parsing...

type 'a foo = int
and 'b bar = 'b option
and ('c, 'd) baz = 'c * 'd -> int list
type 'a foo = unit -> int bar
and 'a bar =
  unit -> (string, int array) baz
and ('a, 'b) baz = unit -> int list foo

Parsing succeeded.
```