### PR TITLE
added support for datatype declarations

### DIFF
--- a/parse/AstType.sml
+++ b/parse/AstType.sml
@@ -233,7 +233,7 @@ struct
     type datbind =
       { elems:
         { tyvars: Token.t SyntaxSeq.t
-        , tycon: MaybeLong.t
+        , tycon: Token.t
         , eq: Token.t
         , elems:
             { opp: Token.t option
@@ -474,7 +474,7 @@ struct
         , eq: Token.t
         , right_datatypee: Token.t
         , right_id: MaybeLong.t
-        }
+       }
 
     (** abstype datbind [withtype typbind] with dec end *)
     | DecAbstype of

--- a/parse/Parser.sml
+++ b/parse/Parser.sml
@@ -507,7 +507,7 @@ struct
 
           val (i, typbind) =
             parse_oneOrMoreDelimitedByReserved
-              {parseElem = parseElem, delim = Token.Bar}
+              {parseElem = parseElem, delim = Token.And}
               i
         in
           (i, typbind)

--- a/parse/Parser.sml
+++ b/parse/Parser.sml
@@ -478,7 +478,98 @@ struct
         end
 
 
-      fun consume_pat infdict restriction i =
+      fun parse_typbind i =
+        let
+          fun parseElem i =
+            let
+              val (i, tyvars) = parse_tyvars i
+              val (i, tycon) =
+                if check Token.isTyCon at i then
+                  (i+1, tok i)
+                else
+                  error
+                    { pos = Token.getSource (tok i)
+                    , what = "Unexpected token. Invalid type constructor."
+                    , explain = NONE
+                    }
+
+              val (i, eq) = parse_reserved Token.Equal i
+              val (i, ty) = consume_ty {permitArrows=true} i
+            in
+              ( i
+              , { tyvars = tyvars
+                , tycon = tycon
+                , eq = eq
+                , ty = ty
+                }
+              )
+            end
+
+          val (i, typbind) =
+            parse_oneOrMoreDelimitedByReserved
+              {parseElem = parseElem, delim = Token.Bar}
+              i
+        in
+          (i, typbind)
+        end
+
+
+      and parse_datbind i =
+        let
+          fun parseConbind i =
+            let
+              val (i, opp) = consume_maybeReserved Token.Op i
+              val (i, id) = parse_vid i
+              val (i, arg) =
+                if not (isReserved Token.Of at i) then
+                  (i, NONE)
+                else
+                  let
+                    val off = tok i
+                    val (i, ty) = consume_ty {permitArrows=true} (i+1)
+                  in
+                    (i, SOME {off = off, ty = ty})
+                  end
+            in
+              ( i
+              , { opp = opp
+                , id = id
+                , arg = arg
+                }
+              )
+            end
+
+          fun parseElem i =
+            let
+              val (i, tyvars) = parse_tyvars i
+              val (i, tycon) = parse_vid i
+              val (i, eq) = parse_reserved Token.Equal i
+
+              val (i, {elems, delims}) =
+                parse_oneOrMoreDelimitedByReserved
+                  {parseElem = parseConbind, delim = Token.Bar}
+                  i
+            in
+              ( i
+              , { tyvars = tyvars
+                , tycon = tycon
+                , eq = eq
+                , elems = elems
+                , delims = delims
+                }
+              )
+            end
+
+          val (i, datbind) =
+            parse_oneOrMoreDelimitedByReserved
+              {parseElem = parseElem, delim = Token.And}
+              i
+        in
+          (i, datbind)
+        end
+
+
+      and consume_pat infdict restriction i =
         let
           val (i, pat) =
             if isReserved Token.Underscore at i then
@@ -878,6 +969,8 @@ struct
           consume_decException (tok i) (i+1, infdict)
         else if isReserved Token.Local at i then
           consume_decLocal (i+1, infdict)
+        else if isReserved Token.Datatype at i then
+          consume_decDatatypeDeclarationOrReplication (i+1, infdict)
         else
           nyi "consume_oneDec" i
 
@@ -1144,36 +1237,7 @@ struct
       and consume_decType (i, infdict) =
         let
           val typee = tok (i-1)
-
-          fun parseElem i =
-            let
-              val (i, tyvars) = parse_tyvars i
-              val (i, tycon) =
-                if check Token.isTyCon at i then
-                  (i+1, tok i)
-                else
-                  error
-                    { pos = Token.getSource (tok i)
-                    , what = "Unexpected token. Invalid type constructor."
-                    , explain = NONE
-                    }
-
-              val (i, eq) = parse_reserved Token.Equal i
-              val (i, ty) = consume_ty {permitArrows=true} i
-            in
-              ( i
-              , { tyvars = tyvars
-                , tycon = tycon
-                , eq = eq
-                , ty = ty
-                }
-              )
-            end
-
-          val (i, typbind) =
-            parse_oneOrMoreDelimitedByReserved
-              {parseElem = parseElem, delim = Token.And}
-              i
+          val (i, typbind) = parse_typbind i
         in
           ( (i, infdict)
           , Ast.Exp.DecType
@@ -1182,6 +1246,64 @@ struct
               }
           )
         end
+
+
+      (** datatype datbind <withtype typbind>
+        *         ^
+        * OR
+        * datatype tycon = datatype longtycon
+        *         ^
+        *)
+      and consume_decDatatypeDeclarationOrReplication (i, infdict) =
+        if (
+          isReserved Token.OpenParen at i (* datatype ('a, ...) foo *)
+          orelse check Token.isTyVar at i (* datatype 'a foo *)
+          orelse ( (* datatype foo = A *)
+            check Token.isValueIdentifierNoEqual at i
+            andalso isReserved Token.Equal at (i+1)
+            andalso not (isReserved Token.Datatype at (i+2))
+          )
+        ) then
+          let
+            val datatypee = tok (i-1)
+            val (i, datbind) = parse_datbind i
+            val (i, withtypee) =
+              if not (isReserved Token.Withtype at i) then
+                (i, NONE)
+              else
+                let
+                  val withtypee = tok i
+                  val (i, typbind) = parse_typbind (i+1)
+                in
+                  (i, SOME {withtypee = withtypee, typbind = typbind})
+                end
+          in
+            ( (i, infdict)
+            , Ast.Exp.DecDatatype
+              { datatypee = datatypee
+              , datbind = datbind
+              , withtypee = withtypee
+              }
+            )
+          end
+        else
+          let
+            val left_datatypee = tok (i-1)
+            val (i, left_id) = parse_vid i
+            val (i, eq) = parse_reserved Token.Equal i
+            val (i, right_datatypee) = parse_reserved Token.Datatype i
+            val (i, right_id) = parse_longvid i
+          in
+            ( (i, infdict)
+            , Ast.Exp.DecReplicateDatatype
+              { left_datatypee = left_datatypee
+              , left_id = left_id
+              , eq = eq
+              , right_datatypee = right_datatypee
+              , right_id = right_id
+              }
+            )
+          end
 
 
       (** val tyvarseq [rec] pat = exp [and [rec] pat = exp ...]

--- a/parse/PrettyPrintAst.sml
+++ b/parse/PrettyPrintAst.sml
@@ -238,10 +238,33 @@ struct
                   )
                 )
               end
+
+            fun show_withtypee {withtypee, typbind = {elems, ...}} =
+              let
+                fun mk mark {tyvars, tycon, eq, ty} =
+                  group (
+                    separateWithSpaces
+                      [ SOME (text (if mark then "withtypee" else "and"))
+                      , SOME (text (Token.toString tycon))
+                      , SOME (text "=")
+                      , SOME (showTy ty)
+                      ]
+                  )
+              in
+                Seq.iterate op$$
+                  (mk true (Seq.nth elems 0))
+                  (Seq.map (mk false) (Seq.drop elems 1))
+              end
+
+            val datbinds =
+              Seq.iterate op$$
+                (show_datbind true (Seq.nth elems 0))
+                (Seq.map (show_datbind false) (Seq.drop elems 1))
           in
-            Seq.iterate op$$
-              (show_datbind true (Seq.nth elems 0))
-              (Seq.map (show_datbind false) (Seq.drop elems 1))
+            case withtypee of
+              SOME result =>
+                datbinds $$ show_withtypee result
+            | _ => datbinds
           end
 
       | DecInfix {precedence, elems, ...} =>

--- a/test/fail/bad-datatypes-1.sml
+++ b/test/fail/bad-datatypes-1.sml
@@ -1,0 +1,3 @@
+datatype foo =
+  | French
+  | Noun

--- a/test/fail/bad-datatypes-2.sml
+++ b/test/fail/bad-datatypes-2.sml
@@ -1,0 +1,1 @@
+datatype 'a 'b = A

--- a/test/succeed/datatypes.sml
+++ b/test/succeed/datatypes.sml
@@ -1,0 +1,20 @@
+
+datatype ('a, 'b) either = INL of 'a | INR of 'b
+datatype foo = A
+
+datatype even = Z | S1 of odd
+and odd = S2 of even
+
+datatype 'a tree = Empty | Node of 'a tree * 'a * 'a tree
+
+datatype ('a, 'b, 'c) complicated =
+    op Con1 of int * string
+  | Con2 of int -> string
+  | Con3
+and complicate = op Cons1 | Cons2 of (int, string, bool) complicated
+and 'a complex = Const
+withtype bar = int
+and 'a baz = string
+
+datatype odd = even
+datatype even = odd


### PR DESCRIPTION
+ Problem: We do not currently support datatype declarations

+ Support: This PR adds parsing for datatype declarations, along with pretty printing. We get stuff like: 
```
λ ~/P/parse-sml on add-datatype-dec ⨯ ./main test/succeed/datatypes.sml                          02:55:14

datatype ('a, 'b) either = INL of 'a | INR of 'b
datatype foo = A

datatype even = Z | S1 of odd
and odd = S2 of even

datatype 'a tree = Empty | Node of 'a tree * 'a * 'a tree

datatype ('a, 'b, 'c) complicated =
    op Con1 of int * string
  | Con2 of int -> string
  | Con3
and complicate = op Cons1 | Cons2 of (int, string, bool) complicated
and 'a complex = Const
withtype bar = int
and 'a baz = string


Lexing succeeded.
Parsing...

datatype either = INL of 'a | INR of 'b
datatype foo = A
datatype even = Z | S1 of odd
and odd = S2 of even
datatype tree =
  Empty | Node of 'a tree * 'a * 'a tree
datatype complicated =
    op Con1 of int * string
  | Con2 of int -> string
  | Con3
and complicate =
    op Cons1
  | Cons2 of (int, string, bool) complicated
and complex = Const
withtypee bar = int
and baz = string

Parsing succeeded.
```

You might want to check me on the pretty printing stuff - I never actually read through all of the Wadler paper. For instance, the `datatype tree` in the above example might not be exactly what you want. I'm not sure of how to fix it, though.

Actually, it parses replicates too now, but it just doesn't pretty print them yet.