### PR TITLE
Eqtype specs, refactored ast type, finished specs type

### DIFF
--- a/lex/Token.sml
+++ b/lex/Token.sml
@@ -397,6 +397,16 @@ struct
     [ Signature
     ]
 
+  val sigSpecStartTokens =
+    [ Val
+    , Type
+    , Eqtype
+    , Datatype
+    , Exception
+    , Structure
+    , Include
+    ]
+
   fun isDecStartToken tok =
     case getClass tok of
       Reserved rc =>
@@ -413,6 +423,12 @@ struct
     case getClass tok of
       Reserved rc =>
         List.exists (fn rc' => rc = rc') sigDecStartTokens
+    | _ => false
+
+  fun isSigSpecStartToken tok =
+    case getClass tok of
+      Reserved rc =>
+        List.exists (fn rc' => rc = rc') sigSpecStartTokens
     | _ => false
 
   fun classToString class =

--- a/parse/AstType.sml
+++ b/parse/AstType.sml
@@ -592,7 +592,7 @@ struct
         , elems:
             { tyvars: Token.t SyntaxSeq.t
             , tycon: Token.t
-            }
+            } Seq.t
         (** 'and' delimiters between mutually recursive types *)
         , delims: Token.t Seq.t
         }

--- a/parse/AstType.sml
+++ b/parse/AstType.sml
@@ -581,7 +581,7 @@ struct
         , elems:
             { tyvars: Token.t SyntaxSeq.t
             , tycon: Token.t
-            }
+            } Seq.t
         (** 'and' delimiters between mutually recursive types *)
         , delims: Token.t Seq.t
         }
@@ -595,6 +595,12 @@ struct
             }
         (** 'and' delimiters between mutually recursive types *)
         , delims: Token.t Seq.t
+        }
+
+    (** spec [[;] spec ...] *)
+    | Multiple of
+        { elems: spec Seq.t
+        , delims: Token.t option Seq.t
         }
 
     (** TODO finish 'spec' type *)

--- a/parse/Parser.sml
+++ b/parse/Parser.sml
@@ -1886,7 +1886,7 @@ struct
             | _ =>
                 makeSpecMultiple ()
         in
-          (i, infdict, result)
+          (i, result)
         end
 
 
@@ -1938,7 +1938,7 @@ struct
       fun consume_sigExpSigEnd infdict i =
         let
           val sigg = tok (i-1)
-          val (i, infdict, spec) = consume_sigSpec infdict i
+          val (i, spec) = consume_sigSpec infdict i
           val (i, endd) = parse_reserved Token.End i
         in
           ( i

--- a/parse/Parser.sml
+++ b/parse/Parser.sml
@@ -1803,11 +1803,91 @@ struct
         end
 
 
-      fun consume_sigSpec infdict i =
+      (** type tyvarseq tycon [and ...]
+        *     ^
+        *)
+      fun consume_sigSpecType infdict i =
+        let
+          val typee = tok (i-1)
+
+          fun parseOne i =
+            let
+              val (i, tyvars) = parse_tyvars i
+              val (i, tycon) = parse_tycon i
+            in
+              ( i
+              , { tyvars = tyvars
+                , tycon = tycon
+                }
+              )
+            end
+
+          val (i, {elems, delims}) =
+            parse_oneOrMoreDelimitedByReserved
+              {parseElem = parseOne, delim = Token.And}
+              i
+        in
+          ( i
+          , Ast.Sig.Type
+              { typee = typee
+              , elems = elems
+              , delims = delims
+              }
+          )
+        end
+
+
+      fun consume_oneSigSpec infdict i =
         if isReserved Token.Val at i then
           consume_sigSpecVal infdict (i+1)
+        else if isReserved Token.Type at i then
+          consume_sigSpecType infdict (i+1)
         else
-          (i, Ast.Sig.EmptySpec)
+          nyi "consume_oneSigSpec" i
+
+
+      and consume_sigSpec infdict i =
+        let
+          fun consume_maybeSemicolon i =
+            if isReserved Token.Semicolon at i then
+              (i+1, SOME (tok i))
+            else
+              (i, NONE)
+
+          val (i, specs) =
+            parse_zeroOrMoreWhile
+              (fn i => check Token.isSigSpecStartToken at i)
+              ( parse_two
+                ( consume_oneSigSpec infdict
+                , consume_maybeSemicolon
+                )
+              )
+              i
+
+          fun makeSpecMultiple () =
+            Ast.Sig.Multiple
+              { elems = Seq.map #1 specs
+              , delims = Seq.map #2 specs
+              }
+
+          val result =
+            case Seq.length specs of
+              0 =>
+                Ast.Sig.EmptySpec
+            | 1 =>
+                let
+                  val (spec, semicolon) = Seq.nth specs 0
+                in
+                  if isSome semicolon then
+                    makeSpecMultiple ()
+                  else
+                    spec
+                end
+            | _ =>
+                makeSpecMultiple ()
+        in
+          (i, infdict, result)
+        end
 
 
       (** sigexp where type tyvarseq tycon = ty [and/where type ...]
@@ -1858,7 +1938,7 @@ struct
       fun consume_sigExpSigEnd infdict i =
         let
           val sigg = tok (i-1)
-          val (i, spec) = consume_sigSpec infdict i
+          val (i, infdict, spec) = consume_sigSpec infdict i
           val (i, endd) = parse_reserved Token.End i
         in
           ( i

--- a/parse/Parser.sml
+++ b/parse/Parser.sml
@@ -1837,11 +1837,46 @@ struct
         end
 
 
+      (** eqtype tyvars tycon [and ...]
+        *       ^
+        *)
+      fun consume_sigSpecEqtype infdict i =
+        let
+          val eqtypee = tok (i-1)
+
+          fun parseOne i =
+            let
+              val (i, tyvars) = parse_tyvars i
+              val (i, tycon) = parse_tycon i
+            in
+              ( i
+              , { tyvars =  tyvars
+                , tycon = tycon
+                }
+              )
+            end
+
+          val (i, {elems, delims}) =
+            parse_oneOrMoreDelimitedByReserved
+              {parseElem = parseOne, delim = Token.And}
+              i
+        in
+          ( i
+          , Ast.Sig.Eqtype
+              { eqtypee = eqtypee
+              , elems = elems
+              , delims = delims
+              }
+          )
+        end
+
       fun consume_oneSigSpec infdict i =
         if isReserved Token.Val at i then
           consume_sigSpecVal infdict (i+1)
         else if isReserved Token.Type at i then
           consume_sigSpecType infdict (i+1)
+        else if isReserved Token.Eqtype at i then
+          consume_sigSpecEqtype infdict (i+1)
         else
           nyi "consume_oneSigSpec" i
 

--- a/parse/PrettyPrintAst.sml
+++ b/parse/PrettyPrintAst.sml
@@ -688,6 +688,20 @@ struct
             (Seq.map (showOne false) (Seq.drop elems 1))
         end
 
+    | Ast.Sig.Eqtype {elems, ...} =>
+        let
+          fun showOne first {tyvars, tycon} =
+            separateWithSpaces
+              [ SOME (text (if first then "eqtype" else "and"))
+              , maybeShowSyntaxSeq tyvars (text o Token.toString)
+              , SOME (text (Token.toString tycon))
+              ]
+        in
+          Seq.iterate op$$
+            (showOne true (Seq.nth elems 0))
+            (Seq.map (showOne false) (Seq.drop elems 1))
+        end
+
     | Ast.Sig.Multiple {elems, delims} =>
         let
           fun showOne i =
@@ -698,8 +712,8 @@ struct
           Util.loop (0, Seq.length elems) empty (fn (prev, i) => prev $$ showOne i)
         end
 
-    | _ =>
-        text "<spec>"
+    (*| _ =>
+        text "<spec>"*)
 
 
 

--- a/parse/PrettyPrintAst.sml
+++ b/parse/PrettyPrintAst.sml
@@ -674,6 +674,30 @@ struct
             (Seq.map (showOne false) (Seq.drop elems 1))
         end
 
+    | Ast.Sig.Type {elems, ...} =>
+        let
+          fun showOne first {tyvars, tycon} =
+            separateWithSpaces
+              [ SOME (text (if first then "type" else "and"))
+              , maybeShowSyntaxSeq tyvars (text o Token.toString)
+              , SOME (text (Token.toString tycon))
+              ]
+        in
+          Seq.iterate op$$
+            (showOne true (Seq.nth elems 0))
+            (Seq.map (showOne false) (Seq.drop elems 1))
+        end
+
+    | Ast.Sig.Multiple {elems, delims} =>
+        let
+          fun showOne i =
+            showSpec (Seq.nth elems i)
+            ++
+            (if Option.isSome (Seq.nth delims i) then text ";" else empty)
+        in
+          Util.loop (0, Seq.length elems) empty (fn (prev, i) => prev $$ showOne i)
+        end
+
     | _ =>
         text "<spec>"
 

--- a/test/succeed/specs.sml
+++ b/test/succeed/specs.sml
@@ -1,0 +1,10 @@
+signature FOO =
+  sig
+    val x : int
+    and y : string
+
+    type foo
+    and bar
+    and 'a baz
+    and ('a, 'b) bat
+  end

--- a/test/succeed/specs.sml
+++ b/test/succeed/specs.sml
@@ -7,4 +7,8 @@ signature FOO =
     and bar
     and 'a baz
     and ('a, 'b) bat
+
+    eqtype 'a functions
+    and are
+    and ('a, 'b) values
   end


### PR DESCRIPTION
Problem: We cannot currently support `eqtype` specifications within a signature. Also, specs is not done.
Solution: Added `eqtype` in, with pretty printing. Also finished off the `spec`s.