### PR TITLE
Fix autoformatting of chains of infix expressions

### DIFF
--- a/src/pretty-print/PrettyExpAndDec.sml
+++ b/src/pretty-print/PrettyExpAndDec.sml
@@ -365,7 +365,27 @@ struct
       | App {left, right} =>
           group (showExp left $$ indent (showExp right))
       | Infix {left, id, right} =>
-          showExp left ++ space ++ token id ++ space ++ showExp right
+          let
+            fun showInfix (Infix {left=l', id=i', right=r'}) i r =
+                        (showInfix l' i' r')
+                        $$ token i
+                        ++ space
+                        ++ showExp r
+              | showInfix l i r =
+                        (case left of
+                              Infix _ => showExp l
+                                         $$ token i
+                                         ++ space
+                                         ++ showExp r
+                            | _ => showExp l
+                                   ++ space
+                                   ++ token i
+                                   ++ space
+                                   ++ showExp r
+                        )
+          in
+            showInfix left id right
+          end
       | Andalso {left, andalsoo, right} =>
           showExp left ++ space ++ token andalsoo ++ space ++ showExp right
       | Orelse {left, orelsee, right} =>


### PR DESCRIPTION
Fixes issue #30

INPUT
```sml
infix 2 ++
val one =
    func1 a ++ func1 b ++ func4 a b c d ++ func3 a b c ++ func5 a b c d e
      ++ func3 a b c ++ func1 b ++ func1 c

val two =
    func1 a ++ func1 b

val three =
    func1 a ++ func1 b ++ func4 a b c d

val four =
    (func a ++ func1 b) ++ func4 a b c d

val five =
    (func a ++ func1 b) ++ (func4 a b c d ++ func3 a b c) ++ func a b c d e
```

OUTPUT:
```sml
infix 2 ++
val one =
  func1 a
  ++ func1 b
  ++ func4 a b c d
  ++ func3 a b c
  ++ func5 a b c d e
  ++ func3 a b c
  ++ func1 b
  ++ func1 c
val two = func1 a ++ func1 b
val three =
  func1 a
  ++ func1 b
  ++ func4 a b c d
val four =
  (func a ++ func1 b) ++ func4 a b c d
val five =
  (func a ++ func1 b)
  ++ (func4 a b c d ++ func3 a b c)
  ++ func a b c d e
```
Note: doesn't alter infix chain formatting in pattern matching expressions