### PR TITLE
Finishes #29: formatting for if-then-else chaining

### DIFF
--- a/src/pretty-print/PrettyExpAndDec.sml
+++ b/src/pretty-print/PrettyExpAndDec.sml
@@ -400,21 +400,23 @@ struct
       | Typed {exp, colon, ty} =>
           showExp exp ++ space ++ token colon ++ space ++ showTy ty
       | IfThenElse {iff, exp1, thenn, exp2, elsee, exp3} =>
-          group ((
-            group (
-              token iff
-              $$
-              indent (showExp exp1)
-              $$
-              token thenn
-            )
-            $$
-            indent (showExp exp2)
-            $$
-            token elsee)
-            +$+
-            indent (showExp exp3)
-          )
+            let
+                val combinator = case exp3 of
+                                      IfThenElse _ => besideAndAboveOrSpace
+                                    | _ => aboveOrSpace
+            in
+                group (
+                  token iff
+                  $$
+                  indent (showExp exp1)
+                  $$
+                  token thenn
+                )
+                $$
+                indent (showExp exp2)
+                $$
+                combinator(token elsee, indent (showExp exp3))
+            end
       | While {whilee, exp1, doo, exp2} =>
           group (
             group (


### PR DESCRIPTION
I think this commit should finish the remaining step for this issue.

I'm not sure if produces pretty output in all cases. It seems fine so far, based on the examples below:

Input:
```sml
val x =
  if b1 then e1
  else if b2 then e2
  else if b3 then e3
  else if b4 then e4
  else if b5 then e5
  else if b6 then e6
  else if b7 then e7
  else e8


val y =
  if b1 then e1
  else if let val y = case z of foo => [1,2,3,4,5,6,8,9,10,11,12] | bar => [1,2,3,4,5,6,8,9,10,11,12] in baz end then e2
  else if b3 then e3
  else if b4 then e4
  else if b5 then e5
  else if b6 then e6
  else if b7 then e7
  else let val y = case z of foo => [1,2,3,4,5,6,8,9,10,11,12] | bar => [1,2,3,4,5,6,8,9,10,11,12] in baz end
```
Output:
```sml
val x =
  if b1 then
    e1
  else if b2 then
    e2
  else if b3 then
    e3
  else if b4 then
    e4
  else if b5 then
    e5
  else if b6 then
    e6
  else if b7 then
    e7
  else
    e8

val y =
  if b1 then
    e1
  else if
    let
      val y =
        case z of
          foo => [1, 2, 3, 4, 5, 6, 8, 9, 10, 11, 12]
        | bar => [1, 2, 3, 4, 5, 6, 8, 9, 10, 11, 12]
    in
      baz
    end
  then
    e2
  else if b3 then
    e3
  else if b4 then
    e4
  else if b5 then
    e5
  else if b6 then
    e6
  else if b7 then
    e7
  else
    let
      val y =
        case z of
          foo => [1, 2, 3, 4, 5, 6, 8, 9, 10, 11, 12]
        | bar => [1, 2, 3, 4, 5, 6, 8, 9, 10, 11, 12]
    in
      baz
    end
```