### PR TITLE
Update module language style

### DIFF
--- a/src/base/PrettySimpleDoc.sml
+++ b/src/base/PrettySimpleDoc.sml
@@ -138,7 +138,7 @@ struct
               loopBeside (d1, d2)
         | Choice {flattened, ...} =>
             flattened
-        | Rigid d => (false, Rigid d, 0 (* TODO *), false)
+        | Rigid d => (false, Rigid d, 0, false)
 
       and loopBeside (d1, d2) =
         let

--- a/src/base/PrettySimpleDoc.sml
+++ b/src/base/PrettySimpleDoc.sml
@@ -50,6 +50,7 @@ sig
   val space: doc
   val softspace: doc
   val group: doc -> doc
+  val rigid: doc -> doc
 
   val pretty: {ribbonFrac: real, maxWidth: int, indentWidth: int}
            -> doc
@@ -71,6 +72,7 @@ struct
   | BesideAndAbove of bool * doc * doc
   | Above of bool * doc * doc
   | Choice of {flattened: (bool * doc * int * bool), normal: doc}
+  | Rigid of doc
 
 
   type t = doc
@@ -136,6 +138,7 @@ struct
               loopBeside (d1, d2)
         | Choice {flattened, ...} =>
             flattened
+        | Rigid d => (false, Rigid d, 0 (* TODO *), false)
 
       and loopBeside (d1, d2) =
         let
@@ -171,6 +174,8 @@ struct
 
   fun group doc =
     Choice {flattened = flatten doc, normal = doc}
+
+  val rigid = Rigid
 
 
   fun spaces count =
@@ -245,6 +250,7 @@ struct
               else
                 layout (am, lnStart, col, acc) normal
             end
+        | Rigid doc => layout (am, lnStart, col, acc) doc
 
       val (_, _, _, strs) = layout (UseCurrentCol, 0, 0, []) inputDoc
     in

--- a/src/pretty-print/PrettyFun.sml
+++ b/src/pretty-print/PrettyFun.sml
@@ -56,7 +56,7 @@ struct
               ]
         \\ showStrExp strexp
     in
-      Seq.iterate op$$
+      rigidVertically
         (showFunctor (functorr, Seq.nth elems 0))
         (Seq.map showFunctor (Seq.zip (delims, Seq.drop elems 1)))
     end

--- a/src/pretty-print/PrettyFun.sml
+++ b/src/pretty-print/PrettyFun.sml
@@ -13,9 +13,7 @@ struct
   open PrettyUtil
 
   infix 2 ++ $$ //
-  fun x ++ y = beside (x, y)
-  fun x $$ y = aboveOrSpace (x, y)
-  fun x // y = aboveOrBeside (x, y)
+  infix 1 \\
 
   fun showTy ty = PrettyTy.showTy ty
   fun showPat pat = PrettyPat.showPat pat
@@ -42,23 +40,21 @@ struct
       fun showFunctor
         (starter, {funid, lparen, funarg, rparen, constraint, eq, strexp})
         =
-        group (
-          group (
-            group (
-              token starter
-              ++ space ++
-              token funid
-              ++ space ++ token lparen ++ showFunArg funarg ++ token rparen
-            )
-            $$
-            (case constraint of NONE => empty | SOME {colon, sigexp} =>
-              indent (token colon ++ space ++ showSigExp sigexp))
-            ++
-            space ++ token eq
-          )
-          $$
-          showStrExp strexp
-        )
+        separateWithSpaces
+          [ SOME (token starter)
+          , SOME (token funid)
+          ]
+        \\ separateWithSpaces
+             [ SOME (token lparen ++ showFunArg funarg ++ token rparen)
+             , Option.map
+                 (fn {colon, ...} => token colon)
+                 constraint
+             ]
+        \\ separateWithSpaces
+              [ Option.map (fn {sigexp, ...} => showSigExp sigexp) constraint
+              , SOME (token eq)
+              ]
+        \\ showStrExp strexp
     in
       Seq.iterate op$$
         (showFunctor (functorr, Seq.nth elems 0))

--- a/src/pretty-print/PrettySig.sml
+++ b/src/pretty-print/PrettySig.sml
@@ -249,7 +249,7 @@ struct
     | Ast.Sig.Spec {sigg, spec, endd} => (
         case spec of
           Ast.Sig.EmptySpec => token sigg ++ space ++ token endd
-        | _                 =>
+        | _ =>
             rigid (
               token sigg
               $$

--- a/src/pretty-print/PrettySig.sml
+++ b/src/pretty-print/PrettySig.sml
@@ -35,7 +35,7 @@ struct
             token vid ++ space ++ token colon ++ space
             ++ showTy ty
         in
-          Seq.iterate op$$
+          rigidVertically
             (showOne (vall, Seq.nth elems 0))
             (Seq.zipWith showOne (delims, Seq.drop elems 1))
         end
@@ -49,7 +49,7 @@ struct
               , SOME (token tycon)
               ]
         in
-          Seq.iterate op$$
+          rigidVertically
             (showOne (typee, Seq.nth elems 0))
             (Seq.zipWith showOne (delims, Seq.drop elems 1))
         end
@@ -65,7 +65,7 @@ struct
               , SOME (showTy ty)
               ]
         in
-          Seq.iterate op$$
+          rigidVertically
             (showOne (typee, Seq.nth elems 0))
             (Seq.zipWith showOne (delims, Seq.drop elems 1))
         end
@@ -79,7 +79,7 @@ struct
               , SOME (token tycon)
               ]
         in
-          Seq.iterate op$$
+          rigidVertically
             (showOne (eqtypee, Seq.nth elems 0))
             (Seq.zipWith showOne (delims, Seq.drop elems 1))
         end
@@ -123,7 +123,7 @@ struct
               )
             end
         in
-          Seq.iterate op$$
+          rigidVertically
             (show_datdesc (datatypee, Seq.nth elems 0))
             (Seq.zipWith show_datdesc (delims, Seq.drop elems 1))
         end
@@ -155,7 +155,7 @@ struct
                   ]
               )
         in
-          Seq.iterate op$$
+          rigidVertically
             (showOne (exceptionn, Seq.nth elems 0))
             (Seq.zipWith showOne (delims, Seq.drop elems 1))
         end
@@ -173,7 +173,7 @@ struct
               indent (showSigExp sigexp)
             )
         in
-          Seq.iterate op$$
+          rigidVertically
             (showOne (structuree, Seq.nth elems 0))
             (Seq.zipWith showOne (delims, Seq.drop elems 1))
         end
@@ -216,7 +216,7 @@ struct
           group (
             showSpec spec
             $$
-            (token sharingg ++ space ++ stuff)
+            rigid (token sharingg ++ space ++ stuff)
           )
         end
 
@@ -236,7 +236,7 @@ struct
           group (
             showSpec spec
             $$
-            (token sharingg ++ space ++ token typee ++ space ++ stuff)
+            rigid (token sharingg ++ space ++ token typee ++ space ++ stuff)
           )
         end
 
@@ -246,18 +246,14 @@ struct
       Ast.Sig.Ident id =>
         token id
 
-    | Ast.Sig.Spec {sigg, spec, endd} => (
-        case spec of
-          Ast.Sig.EmptySpec => token sigg ++ space ++ token endd
-        | _ =>
-            rigid (
-              token sigg
-              $$
-              indent (showSpec spec)
-              $$
-              token endd
-            )
-      )
+    | Ast.Sig.Spec {sigg, spec, endd} =>
+        group (
+          token sigg
+          $$
+          indent (showSpec spec)
+          $$
+          token endd
+        )
 
     | Ast.Sig.WhereType {sigexp, elems} =>
         let
@@ -289,7 +285,7 @@ struct
           indent (showSigExp sigexp)
         )
     in
-      Seq.iterate op$$
+      rigidVertically
         (showOne (signaturee, Seq.nth elems 0))
         (Seq.zipWith showOne (delims, Seq.drop elems 1))
     end

--- a/src/pretty-print/PrettyStr.sml
+++ b/src/pretty-print/PrettyStr.sml
@@ -70,7 +70,7 @@ struct
             else
               group topPart
         in
-          rigid (
+          group (
             topPart
             $$
             indent (group (showStrExp strexp))
@@ -104,7 +104,7 @@ struct
                   ]
             \\ showStrExp strexp
         in
-          Seq.iterate op$$
+          rigidVertically
             (showOne (structuree, Seq.nth elems 0))
             (Seq.map showOne (Seq.zip (delims, (Seq.drop elems 1))))
         end
@@ -155,7 +155,7 @@ struct
             front
             $$
             indent (
-              Seq.iterate op$$
+              rigidVertically
                 (token (MaybeLongToken.getToken (Seq.nth elems 0)))
                 (Seq.zipWith showOne (delims, Seq.drop elems 1))
             )

--- a/src/pretty-print/PrettyStr.sml
+++ b/src/pretty-print/PrettyStr.sml
@@ -32,7 +32,7 @@ struct
     | Ast.Str.Struct {structt, strdec, endd} => (
         case strdec of
           Ast.Str.DecEmpty => token structt ++ space ++ token endd
-        | _                =>
+        | _ =>
             rigid (
               token structt
               $$

--- a/src/pretty-print/PrettyUtil.sml
+++ b/src/pretty-print/PrettyUtil.sml
@@ -8,9 +8,11 @@ struct
 
   open TokenDoc
   infix 2 ++ $$ //
+  infix 1 \\
   fun x ++ y = beside (x, y)
   fun x $$ y = aboveOrSpace (x, y)
   fun x // y = aboveOrBeside (x, y)
+  fun x \\ y = group (x $$ indent y)
 
   fun seqWithSpaces elems f =
     if Seq.length elems = 0 then empty else

--- a/src/pretty-print/PrettyUtil.sml
+++ b/src/pretty-print/PrettyUtil.sml
@@ -52,6 +52,10 @@ struct
           List.foldl (fn (next, prev) => prev ++ space ++ next) first rest
     end
 
+  fun rigidVertically (item: doc) (items: doc Seq.t) : doc =
+    if Seq.length items = 0 then item else
+      rigid (Seq.iterate op$$ item items)
+
 
   fun maybeShowSyntaxSeq s f =
     case s of

--- a/src/pretty-print/TokenDoc.sml
+++ b/src/pretty-print/TokenDoc.sml
@@ -451,7 +451,7 @@ struct
             let
               val (_, d') = loop d
             in
-              (false, d')
+              (false, StringDoc.rigid d')
             end
 
       val (_, d') = loop d

--- a/src/pretty-print/TokenDoc.sml
+++ b/src/pretty-print/TokenDoc.sml
@@ -43,6 +43,7 @@ sig
   val space: doc
   val softspace: doc
   val group: doc -> doc
+  val rigid: doc -> doc
 
   val insertBlankLines: doc -> doc
   val insertComments: doc -> doc
@@ -65,12 +66,14 @@ struct
   | BesideAndAbove of bool * doc * doc
   | Above of bool * doc * doc
   | Group of doc
+  | Rigid of doc
 
   type t = doc
 
   val empty = Empty
   val token = Token
   val group = Group
+  val rigid = Rigid
   fun indent d = Indent d
 
   fun beside (doc1, doc2) =
@@ -173,6 +176,13 @@ struct
                     Above (b, d1', d2')
             in
               (first, result, last)
+            end
+
+        | Rigid d =>
+            let
+              val (first, d', last) = doDoc d
+            in
+              (first, Rigid d', last)
             end
 
         | _ => (NONE, doc, NONE)
@@ -421,6 +431,13 @@ struct
                 (true, StringDoc.group d')
               else
                 (false, d')
+            end
+
+        | Rigid d =>
+            let
+              val (_, d') = loop d
+            in
+              (false, d')
             end
 
       val (_, d') = loop d


### PR DESCRIPTION
Known bugs:
- [x] Sometimes eats comments, e.g.
```sml
structure S =
  struct
    val x = 3
    (* hi *)
  end
```
- ~~(`include` followed by `sharing` moves `sharing` to `include` line; although, doesn't seem to be due to changes here)~~ moved to #37