### PR TITLE
made curried function types nicer

### DIFF
--- a/src/pretty-print/PrettyTy.sml
+++ b/src/pretty-print/PrettyTy.sml
@@ -54,17 +54,17 @@ struct
           end
       | Arrow {from = left, arrow, to = right} =>
           let
-            fun show_arrow ldoc arrow r =
+            fun show_arrow l arrow r =
               case (r, right) of
                 (Arrow {from = l', arrow = arrow', to = r'}, _) =>
-                  ldoc
-                  $$ (token arrow +$+ show_arrow (showTy l') arrow' r')
+                  showTy l
+                  $$ ((spaces 2 ++ token arrow) +$+ show_arrow l' arrow' r')
               | (_, Arrow _) =>
-                  ldoc
-                  $$ (token arrow ++ space ++ showTy r)
-              | _ => ldoc ++ space ++ token arrow ++ space ++ showTy r
+                  showTy l
+                  $$ (spaces 2 ++ token arrow ++ space ++ showTy r)
+              | _ => showTy l ++ space ++ token arrow ++ space ++ showTy r
           in
-            group (show_arrow (spaces 3 ++ showTy left) arrow right)
+            group (show_arrow left arrow right)
           end
     end
 

--- a/src/pretty-print/PrettyTy.sml
+++ b/src/pretty-print/PrettyTy.sml
@@ -12,10 +12,13 @@ struct
   open TokenDoc
   open PrettyUtil
 
-  infix 2 ++ $$ //
+  infix 2 ++ $$ // +/+ +$+
   fun x ++ y = beside (x, y)
   fun x $$ y = aboveOrSpace (x, y)
   fun x // y = aboveOrBeside (x, y)
+
+  fun x +/+ y = besideAndAbove (x, y)
+  fun x +$+ y = besideAndAboveOrSpace (x, y)
 
   fun showTy ty =
     let
@@ -49,8 +52,20 @@ struct
           in
             sequence left delims right (Seq.map showElem elems)
           end
-      | Arrow {from, arrow, to} =>
-          showTy from ++ space ++ token arrow ++ space ++ showTy to
+      | Arrow {from = left, arrow, to = right} =>
+          let
+            fun show_arrow ldoc arrow r =
+              case (r, right) of
+                (Arrow {from = l', arrow = arrow', to = r'}, _) =>
+                  ldoc
+                  $$ (token arrow +$+ show_arrow (showTy l') arrow' r')
+              | (_, Arrow _) =>
+                  ldoc
+                  $$ (token arrow ++ space ++ showTy r)
+              | _ => ldoc ++ space ++ token arrow ++ space ++ showTy r
+          in
+            group (show_arrow (spaces 3 ++ showTy left) arrow right)
+          end
     end
 
 end


### PR DESCRIPTION
Currently, arrow types naively recurse on the left and right, and result in the following format:
![image](https://user-images.githubusercontent.com/49291449/175803862-739473eb-d54d-47a5-94be-1da81c65069e.png)

After this update, it will instead do the following:
![image](https://user-images.githubusercontent.com/49291449/175803860-27539c81-22b6-409e-bbe6-28e96198b5a3.png)

If you're not crazy about the space before the start of the entire type, then you can remove the `spaces 3` I put on line 67.