### PR TITLE
Tabbed doc: declarative `at`

### DIFF
--- a/src/base/PrettyTabbedDoc.sml
+++ b/src/base/PrettyTabbedDoc.sml
@@ -41,7 +41,7 @@ sig
   type tab
   val root: tab
   val newTab: tab -> style * (tab -> doc) -> doc
-  val goto: tab -> doc
+  val at: tab -> doc -> doc
   val cond: tab -> {inactive: doc, active: doc} -> doc
 
   val pretty: {ribbonFrac: real, maxWidth: int, indentWidth: int, debug: bool}
@@ -209,7 +209,7 @@ struct
   | Newline
   | Concat of doc * doc
   | Text of CustomString.t
-  | Goto of tab
+  | At of tab * doc
   | NewTab of {parent: tab, tab: tab, doc: doc}
   | Cond of {tab: tab, inactive: doc, active: doc}
 
@@ -219,16 +219,7 @@ struct
   val newline = Newline
   val space = Space
   val text = Text
-  val goto = Goto
-
-  fun hasNoBreaks doc =
-    case doc of
-      Goto _ => false
-    | Concat (d1, d2) => hasNoBreaks d1 andalso hasNoBreaks d2
-    | NewTab {doc=d, ...} => hasNoBreaks d
-    | Cond {inactive, active, ...} =>
-        hasNoBreaks inactive andalso hasNoBreaks active
-    | _ => true
+  fun at t d = At (t, d)
 
   fun cond tab {inactive, active} =
     Cond {tab=tab, inactive=inactive, active=active}
@@ -249,29 +240,6 @@ struct
 
   (* ====================================================================== *)
 
-  fun allOuterBreaksActivated tab doc =
-    let
-      fun isInList xs x =
-        List.exists (fn y => Tab.eq (x, y)) xs
-
-      fun loop innerTabs doc =
-        case doc of
-          Empty => true
-        | Space => true
-        | Newline => true
-        | Concat (d1, d2) =>
-            loop innerTabs d1
-            andalso loop innerTabs d2
-        | Text _ => true
-        | Goto tab' => isInList innerTabs tab' orelse Tab.isActivated tab'
-        | NewTab {tab=tab', doc=d, ...} => loop (tab' :: innerTabs) d
-        | Cond {active, ...} => loop innerTabs active
-    in
-      loop [tab] doc
-    end
-
-  (* ====================================================================== *)
-
   fun allTabsInDoc d =
     let
       fun loop acc d =
@@ -279,6 +247,7 @@ struct
           NewTab {tab, doc, ...} => loop (tab :: acc) doc
         | Concat (d1, d2) => loop (loop acc d1) d2
         | Cond {inactive, active, ...} => loop (loop acc inactive) active
+        | At (_, doc) => loop acc doc
         | _ => acc
     in
       loop [] d
@@ -917,7 +886,7 @@ struct
         | Concat (doc1, doc2) =>
             layout (layout state doc1) doc2
 
-        | Goto tab =>
+        | At (tab, doc) =>
             let
               val LS (dbgState, ct, lnStart, col, acc) = state
 
@@ -943,38 +912,41 @@ struct
                   (* Fall back on advancing the current line to meet the tab,
                     * which is a little strange, but better than nothing. *)
                   dbgBreak tab (check (LS (dbgState, tab, lnStart, i, Item.Spaces (i-col) :: acc)))
-            in
-              case Tab.getState tab of
-                Tab.Usable Tab.Flattened =>
-                  if Tab.isRigid tab then
-                    raise DoPromote (valOf (oldestPromotableParent tab))
-                  else
-                    LS (dbgState, tab, lnStart, col, acc)
 
-              | Tab.Usable (Tab.Activated (SOME i)) =>
-                  goto i
-
-              | Tab.Usable (Tab.Activated NONE) =>
-                  if Tab.isInplace tab then
-                    if col < parentTabCol tab then
-                      ( Tab.setState tab (Tab.Usable (Tab.Activated (SOME (parentTabCol tab))))
-                      ; goto (parentTabCol tab)
-                      )
+              val state' =
+                case Tab.getState tab of
+                  Tab.Usable Tab.Flattened =>
+                    if Tab.isRigid tab then
+                      raise DoPromote (valOf (oldestPromotableParent tab))
                     else
-                      ( Tab.setState tab (Tab.Usable (Tab.Activated (SOME col)))
-                      ; dbgBreak tab (LS (dbgState, tab, lnStart, col, acc))
-                      )
-                  else
-                    let
-                      val i = indentWidth + parentTabCol tab
-                    in
-                      ( Tab.setState tab (Tab.Usable (Tab.Activated (SOME i)))
-                      ; goto i
-                      )
-                    end
+                      LS (dbgState, tab, lnStart, col, acc)
 
-              | _ =>
-                  raise Fail "PrettyTabbedDoc.pretty.Goto: bad tab"
+                | Tab.Usable (Tab.Activated (SOME i)) =>
+                    goto i
+
+                | Tab.Usable (Tab.Activated NONE) =>
+                    if Tab.isInplace tab then
+                      if col < parentTabCol tab then
+                        ( Tab.setState tab (Tab.Usable (Tab.Activated (SOME (parentTabCol tab))))
+                        ; goto (parentTabCol tab)
+                        )
+                      else
+                        ( Tab.setState tab (Tab.Usable (Tab.Activated (SOME col)))
+                        ; dbgBreak tab (LS (dbgState, tab, lnStart, col, acc))
+                        )
+                    else
+                      let
+                        val i = indentWidth + parentTabCol tab
+                      in
+                        ( Tab.setState tab (Tab.Usable (Tab.Activated (SOME i)))
+                        ; goto i
+                        )
+                      end
+
+                | _ =>
+                    raise Fail "PrettyTabbedDoc.pretty.Goto: bad tab"
+            in
+              layout state' doc
             end
 
         | Cond {tab, inactive, active} =>

--- a/src/prettier-print/PrettierExpAndDec.sml
+++ b/src/prettier-print/PrettierExpAndDec.sml
@@ -149,7 +149,8 @@ struct
       | Record {left, elems, delims, right} =>
           let
             fun showRow {lab, eq, exp} =
-              token lab ++ token eq ++ (withNewChild showExp tab) exp
+              newTab tab (fn inner =>
+                at inner (token lab ++ token eq ++ (withNewChild showExp inner) exp))
           in
             showSequence tab
               { openn = left

--- a/src/prettier-print/PrettierExpAndDec.sml
+++ b/src/prettier-print/PrettierExpAndDec.sml
@@ -57,12 +57,12 @@ struct
   fun showTypbind tab (front, typbind: Ast.Exp.typbind as {elems, delims}) =
     let
       fun showOne first (starter, {tyvars, tycon, ty, eq}) =
-        (if first then empty else goto tab) ++
-        token starter ++
-        showSyntaxSeq token tab tyvars ++
-        token tycon ++
-        token eq ++
-        withNewChild showTy tab ty
+        maybeAt tab (not first)
+          (token starter ++
+          showSyntaxSeq token tab tyvars ++
+          token tycon ++
+          token eq ++
+          withNewChild showTy tab ty)
     in
       Seq.iterate op++
         (showOne true (front, Seq.nth elems 0))
@@ -74,19 +74,20 @@ struct
     newTab tab (fn tab =>
     let
       fun showCon (starter, {opp, id, arg}) =
-        goto tab ++ starter ++
-        showOption token opp ++
-        token id ++
-        showOption (fn {off, ty} => token off ++ withNewChild showTy tab ty) arg
+        at tab
+          (starter ++
+          showOption token opp ++
+          token id ++
+          showOption (fn {off, ty} => token off ++ withNewChild showTy tab ty) arg)
 
       fun showOne (starter, {tyvars, tycon, eq, elems, delims}) =
         let
           val initial =
-            goto tab ++
-            token starter ++
-            showSyntaxSeq token tab tyvars ++
-            token tycon ++
-            token eq
+            at tab
+              (token starter ++
+              showSyntaxSeq token tab tyvars ++
+              token tycon ++
+              token eq)
 
           val skipper = cond tab {inactive=empty, active=space++space}
           fun dd delim = token delim ++ space
@@ -188,38 +189,44 @@ struct
           newTab tab (fn inner => (* do we need the newTab here? *)
           let
             fun mk (delim, {pat, arrow, exp}) =
-              goto inner
-              ++ cond inner {inactive=empty, active=space} ++ token delim
-              ++ withNewChild showPat inner pat ++ token arrow
-              ++ withNewChild showExp inner exp
+              at inner
+                (cond inner {inactive=empty, active=space} ++ token delim
+                ++ withNewChild showPat inner pat ++ token arrow
+                ++ withNewChild showExp inner exp)
 
             val {pat, arrow, exp} = Seq.nth elems 0
-            val initial = goto inner ++ token fnn ++ withNewChild showPat inner pat ++ token arrow ++ withNewChild showExp inner exp
+            val initial =
+              at inner
+                (token fnn
+                ++ withNewChild showPat inner pat
+                ++ token arrow
+                ++ withNewChild showExp inner exp)
           in
             Seq.iterate op++ initial (Seq.map mk (Seq.zip (delims, Seq.drop elems 1)))
           end)
 
       | Case {casee, exp=expTop, off, elems, delims} =>
           newTab tab (fn inner1 =>
+          newTab inner1 (fn inner2 =>
             let
               fun showBranch {pat, arrow, exp} =
                 withNewChild showPat inner1 pat ++ token arrow ++ withNewChild showExp inner1 exp
               fun mk (delim, branch) =
-                goto inner1
-                ++ (case delim of
-                     SOME d => token d
-                   | _ => cond inner1 {active = space ++ space, inactive = empty})
-                ++ showBranch branch
+                at inner1
+                  ((case delim of
+                      SOME d => token d
+                    | _ => cond inner1 {active = space ++ space, inactive = empty})
+                  ++ showBranch branch)
             in
-              goto inner1
-              ++ token casee ++
-              newTab inner1 (fn inner2 =>
-                goto inner2 ++ showExp inner2 expTop
-                ++ cond inner2 {inactive = empty, active = goto inner1})
-              ++ token off
-              ++ Seq.iterate op++ (mk (NONE, Seq.nth elems 0))
-                   (Seq.zipWith mk (Seq.map SOME delims, Seq.drop elems 1))
-            end)
+              at inner1 (token casee)
+              ++
+              at inner2 (showExp inner2 expTop)
+              ++
+              cond inner2 {inactive = token off, active = at inner1 (token off)}
+              ++
+              Seq.iterate op++ (mk (NONE, Seq.nth elems 0))
+                (Seq.zipWith mk (Seq.map SOME delims, Seq.drop elems 1))
+            end))
 
       | Infix {left, id, right} =>
           showInfixedExpAt tab (left, id, right)
@@ -234,10 +241,9 @@ struct
           newTab tab (fn inner1 =>
           newTab tab (fn inner2 =>
             token whilee ++
-            goto inner1 ++ showExp inner1 exp1 ++
-            cond inner1 {inactive = empty, active = goto tab} ++
-            token doo ++
-            goto inner2 ++ showExp inner2 exp2))
+            at inner1 (showExp inner1 exp1) ++
+            cond inner1 {inactive = token doo, active = at tab (token doo)} ++
+            at inner2 (showExp inner2 exp2)))
 
       | Raise {raisee, exp} =>
           token raisee ++ withNewChild showExp tab exp
@@ -248,15 +254,14 @@ struct
               fun showBranch {pat, arrow, exp} =
                 withNewChild showPat inner pat ++ token arrow ++ withNewChild showExp inner exp
               fun mk (delim, branch) =
-                goto inner
-                ++ (case delim of
-                     SOME d => token d
-                   | _ => cond inner {active = space ++ space, inactive = empty})
-                ++ showBranch branch
+                at inner
+                  ((case delim of
+                      SOME d => token d
+                    | _ => cond inner {active = space ++ space, inactive = empty})
+                  ++ showBranch branch)
             in
               showExp tab expLeft ++
-              goto inner ++
-              token handlee ++
+              at inner (token handlee) ++
               Seq.iterate op++ (mk (NONE, Seq.nth elems 0))
                 (Seq.zipWith mk (Seq.map SOME delims, Seq.drop elems 1))
             end)
@@ -283,8 +288,8 @@ struct
                 NONE
               else
                 SOME
-                  (goto tab ++ showInfixedExpAt inner (ll, lt, lr)
-                  ++ goto inner ++ token t ++ withNewChild showExp inner r)
+                  (at tab (showInfixedExpAt inner (ll, lt, lr))
+                  ++ at inner (token t ++ withNewChild showExp inner r))
 
         fun tryRight () =
           case tryViewAsInfix r of
@@ -294,11 +299,13 @@ struct
                 NONE
               else
                 SOME
-                  (showExp tab l ++ goto inner ++ token t
-                  ++ showInfixedExpAt inner (rl, rt, rr))
+                  (showExp tab l
+                  ++ at inner
+                    (token t
+                    ++ showInfixedExpAt inner (rl, rt, rr)))
 
         fun normal () =
-          goto tab ++ showExp inner l ++ goto inner ++ token t ++ withNewChild showExp inner r
+          at tab (showExp inner l) ++ at inner (token t ++ withNewChild showExp inner r)
       in
         case tryLeft () of
           SOME x => x
@@ -318,16 +325,16 @@ struct
       fun d i = Seq.nth delims i
       fun withDelims innerTab =
         Seq.mapIdx (fn (i, e) =>
-          goto innerTab
-          ++ showExp innerTab e
-          ++ (if i = numExps - 1 then empty else nospace ++ token (d i)))
+          at innerTab
+            (showExp innerTab e
+            ++ (if i = numExps - 1 then empty else nospace ++ token (d i))))
         exps
     in
       newTabWithStyle outerTab (Indented, fn inner =>
         showThingSimilarToLetInEnd outerTab
           { lett = lett
           , isEmpty1 = decIsEmpty dec
-          , doc1 = goto inner ++ showDec inner dec
+          , doc1 = at inner (showDec inner dec)
           , inn = inn
           , doc2 = Seq.iterate op++ empty (withDelims inner)
           , endd = endd
@@ -342,7 +349,7 @@ struct
       open Ast.Exp
       val (chain, last) = ifThenElseChain [] exp
 
-      fun breakShowAt tab e = goto tab ++ showExp tab e
+      fun breakShowAt tab e = at tab (showExp tab e)
 
       fun f i =
         let
@@ -350,10 +357,9 @@ struct
         in
           token iff ++
           breakShowAt inner1 exp1 ++
-          cond inner1 {inactive = empty, active = goto outer} ++
-          token thenn ++
+          cond inner1 {inactive = token thenn, active = at outer (token thenn)} ++
           breakShowAt inner2 exp2 ++
-          goto outer ++ token elsee
+          at outer (token elsee)
         end
     in
       Util.loop (0, Seq.length chain) empty (fn (d, i) => d ++ f i)
@@ -372,11 +378,12 @@ struct
       | DecVal {vall, tyvars, elems, delims} =>
           let
             fun mk (delim, {recc, pat, eq, exp}) =
-              goto tab ++ token delim
-              ++ showOption token recc
-              ++ withNewChild showPat tab pat
-              ++ token eq
-              ++ withNewChild showExp tab exp
+              at tab
+                (token delim
+                ++ showOption token recc
+                ++ withNewChild showPat tab pat
+                ++ token eq
+                ++ withNewChild showExp tab exp)
 
             val first =
               let
@@ -410,9 +417,9 @@ struct
       | DecMultiple {elems, delims} =>
           let
             fun mk first (elem, delim) =
-              (if first then empty else goto tab)
-              ++ showDec tab elem
-              ++ showOption (fn d => nospace ++ token d) delim
+              maybeAt tab (not first)
+                (showDec tab elem
+                ++ showOption (fn d => nospace ++ token d) delim)
 
             val things = Seq.zip (elems, delims)
           in
@@ -432,7 +439,7 @@ struct
       | DecDatatype {datatypee, datbind, withtypee} =>
           showDatbind tab (datatypee, datbind)
           ++ showOption (fn {withtypee, typbind} =>
-               goto tab ++ showTypbind tab (withtypee, typbind))
+               at tab (showTypbind tab (withtypee, typbind)))
              withtypee
 
       | DecException {exceptionn, elems, delims} =>
@@ -450,8 +457,8 @@ struct
                   ++ token (MaybeLongToken.getToken right_id)
 
             fun showOne first (starter, elem) =
-              (if first then empty else goto tab)
-              ++ token starter ++ showExbind elem
+              maybeAt tab (not first)
+                (token starter ++ showExbind elem)
           in
             Seq.iterate op++
               (showOne true (exceptionn, Seq.nth elems 0))
@@ -485,15 +492,15 @@ struct
               showDatbind tab (abstypee, datbind)
 
             val bottom =
-              goto tab
-              ++ token withh
-              ++ withNewChildWithStyle Indented showDec tab dec
-              ++ goto tab
-              ++ token endd
+              at tab
+                (token withh
+                ++ withNewChildWithStyle Indented showDec tab dec)
+              ++
+              at tab (token endd)
           in
             showDatbind tab (abstypee, datbind)
             ++ showOption (fn {withtypee, typbind} =>
-                 goto tab ++ showTypbind tab (withtypee, typbind))
+                 at tab (showTypbind tab (withtypee, typbind)))
                withtypee
             ++ bottom
           end
@@ -525,13 +532,13 @@ struct
         token colon ++ withNewChild showTy tab ty
 
       fun showClause isVeryTop isFirst (front, {fname_args, ty, eq, exp}) =
-        (if isVeryTop then empty else goto tab)
-        ++ (if isFirst then empty else cond tab {active=space++space, inactive=empty})
-        ++ front
-        ++ showFNameArgs fname_args
-        ++ showOption showColonTy ty
-        ++ token eq
-        ++ withNewChild showExp tab exp
+        maybeAt tab (not isVeryTop)
+          ( (if isFirst then empty else cond tab {active=space++space, inactive=empty})
+          ++ front
+          ++ showFNameArgs fname_args
+          ++ showOption showColonTy ty
+          ++ token eq
+          ++ withNewChild showExp tab exp)
 
       fun mkFunction isVeryTop (starter, {elems=innerElems, delims}) =
         let in

--- a/src/prettier-print/PrettierFun.sml
+++ b/src/prettier-print/PrettierFun.sml
@@ -77,14 +77,14 @@ struct
             first
             (starter, {funid, lparen, funarg, rparen, constraint, eq, strexp})
         =
-          (if first then empty else at tab)
+          (if first then empty else goto tab)
           ++ token starter ++ token funid
           ++ (if funArgWantsSpaceBefore funarg then
                 space
               else
                 nospace)
           ++ newTab tab (fn inner =>
-              at inner
+              goto inner
               ++ token lparen ++ nospace
               ++ showFunArg inner funarg ++ nospace
               ++ token rparen)
@@ -96,13 +96,13 @@ struct
                    nospace)
                 ++ token colon
                 ++ (if sigExpWantsSameTabAsDec sigexp then
-                      at tab ++ showSigExp tab sigexp
+                      goto tab ++ showSigExp tab sigexp
                     else
                       withNewChild showSigExp tab sigexp))
               constraint
           ++ token eq
           ++ (if strExpWantsSameTabAsDec strexp then
-                at tab ++ showStrExp tab strexp
+                goto tab ++ showStrExp tab strexp
               else
                 withNewChild showStrExp tab strexp)
     in

--- a/src/prettier-print/PrettierFun.sml
+++ b/src/prettier-print/PrettierFun.sml
@@ -77,34 +77,34 @@ struct
             first
             (starter, {funid, lparen, funarg, rparen, constraint, eq, strexp})
         =
-          (if first then empty else goto tab)
-          ++ token starter ++ token funid
-          ++ (if funArgWantsSpaceBefore funarg then
-                space
-              else
-                nospace)
-          ++ newTab tab (fn inner =>
-              goto inner
-              ++ token lparen ++ nospace
-              ++ showFunArg inner funarg ++ nospace
-              ++ token rparen)
-          ++ showOption
-              (fn {colon, sigexp} =>
-                (if Token.getClass colon = Token.Reserved Token.ColonArrow then
-                   space
-                 else
-                   nospace)
-                ++ token colon
-                ++ (if sigExpWantsSameTabAsDec sigexp then
-                      goto tab ++ showSigExp tab sigexp
-                    else
-                      withNewChild showSigExp tab sigexp))
-              constraint
-          ++ token eq
-          ++ (if strExpWantsSameTabAsDec strexp then
-                goto tab ++ showStrExp tab strexp
-              else
-                withNewChild showStrExp tab strexp)
+          maybeAt tab (not first)
+            (token starter ++ token funid
+            ++ (if funArgWantsSpaceBefore funarg then
+                  space
+                else
+                  nospace)
+            ++ newTab tab (fn inner =>
+                at inner
+                  (token lparen ++ nospace
+                  ++ showFunArg inner funarg ++ nospace
+                  ++ token rparen))
+            ++ showOption
+                (fn {colon, sigexp} =>
+                  (if Token.getClass colon = Token.Reserved Token.ColonArrow then
+                    space
+                  else
+                    nospace)
+                  ++ token colon
+                  ++ (if sigExpWantsSameTabAsDec sigexp then
+                        at tab (showSigExp tab sigexp)
+                      else
+                        withNewChild showSigExp tab sigexp))
+                constraint
+            ++ token eq
+            ++ (if strExpWantsSameTabAsDec strexp then
+                  at tab (showStrExp tab strexp)
+                else
+                  withNewChild showStrExp tab strexp))
     in
       Seq.iterate op++
         (showFunctor true (functorr, Seq.nth elems 0))

--- a/src/prettier-print/PrettierPat.sml
+++ b/src/prettier-print/PrettierPat.sml
@@ -78,7 +78,9 @@ struct
               case patrow of
                 DotDotDot ddd => token ddd
               | LabEqPat {lab, eq, pat} =>
-                  token lab ++ token eq ++ withNewChild showPat tab pat
+                  newTab tab (fn inner =>
+                    at inner
+                      (token lab ++ token eq ++ withNewChild showPat inner pat))
               | LabAsPat {id, ty, aspat} =>
                   token id ++
                   showOption (fn {colon, ty} =>

--- a/src/prettier-print/PrettierPrintAst.sml
+++ b/src/prettier-print/PrettierPrintAst.sml
@@ -44,7 +44,7 @@ struct
         val all = Seq.map (showOneAt root) tds
       in
         Seq.iterate op++ (Seq.nth all 0)
-          (Seq.map (fn x => goto root ++ x) (Seq.drop all 1))
+          (Seq.map (at root) (Seq.drop all 1))
       end
 
 

--- a/src/prettier-print/PrettierPrintAst.sml
+++ b/src/prettier-print/PrettierPrintAst.sml
@@ -44,7 +44,7 @@ struct
         val all = Seq.map (showOneAt root) tds
       in
         Seq.iterate op++ (Seq.nth all 0)
-          (Seq.map (fn x => at root ++ x) (Seq.drop all 1))
+          (Seq.map (fn x => goto root ++ x) (Seq.drop all 1))
       end
 
 

--- a/src/prettier-print/PrettierSig.sml
+++ b/src/prettier-print/PrettierSig.sml
@@ -46,14 +46,14 @@ struct
     newTab tab (fn tab =>
     let
       fun showCon (starter, {vid, arg}) =
-        at tab ++ starter ++
+        goto tab ++ starter ++
         token vid ++
         showOption (fn {off, ty} => token off ++ withNewChild showTy tab ty) arg
 
       fun showOne (starter, {tyvars, tycon, eq, elems, delims}) =
         let
           val initial =
-            at tab ++
+            goto tab ++
             token starter ++
             showSyntaxSeq token tab tyvars ++
             token tycon ++
@@ -86,7 +86,7 @@ struct
       | Val {vall, elems, delims} =>
           let
             fun showOne first (starter, {vid, colon, ty}) =
-              (if first then empty else at tab)
+              (if first then empty else goto tab)
               ++ token starter ++ token vid ++
               (if Token.isSymbolicIdentifier vid then space else nospace)
               ++ token colon ++ withNewChild showTy tab ty
@@ -99,7 +99,7 @@ struct
       | Type {typee, elems, delims} =>
           let
             fun showOne first (starter, {tyvars, tycon}) =
-              (if first then empty else at tab)
+              (if first then empty else goto tab)
               ++ token starter
               ++ showSyntaxSeq token tab tyvars
               ++ token tycon
@@ -112,7 +112,7 @@ struct
       | TypeAbbreviation {typee, elems, delims} =>
           let
             fun showOne first (starter, {tyvars, tycon, eq, ty}) =
-              (if first then empty else at tab)
+              (if first then empty else goto tab)
               ++ token starter
               ++ showSyntaxSeq token tab tyvars
               ++ token tycon
@@ -127,7 +127,7 @@ struct
       | Eqtype {eqtypee, elems, delims} =>
           let
             fun showOne first (starter, {tyvars, tycon}) =
-              (if first then empty else at tab)
+              (if first then empty else goto tab)
               ++ token starter
               ++ showSyntaxSeq token tab tyvars
               ++ token tycon
@@ -140,7 +140,7 @@ struct
       | Multiple {elems, delims} =>
           let
             fun showOne first (elem: spec, delim: Token.t option) =
-              (if first then empty else at tab)
+              (if first then empty else goto tab)
               ++ showSpec tab elem
               ++ showOption (fn d => nospace ++ token d) delim
 
@@ -154,7 +154,7 @@ struct
       | Exception {exceptionn, elems, delims} =>
           let
             fun showOne first (starter, {vid, arg}) =
-              (if first then empty else at tab)
+              (if first then empty else goto tab)
               ++ token starter
               ++ token vid
               ++ showOption (fn {off, ty} => token off ++ withNewChild showTy tab ty) arg
@@ -167,14 +167,14 @@ struct
       | Structure {structuree, elems, delims} =>
           let
             fun showOne first (starter, {id, colon, sigexp}) =
-              (if first then empty else at tab)
+              (if first then empty else goto tab)
               ++ token starter
               ++ token id
               (* NOTE: nospace should be safe here, because structure
                * identifiers cannot be symbolic *)
               ++ nospace ++ token colon
               ++ (if sigExpWantsSameTabAsDec sigexp then
-                    at tab ++ showSigExp tab sigexp
+                    goto tab ++ showSigExp tab sigexp
                   else
                     withNewChild showSigExp tab sigexp)
           in
@@ -195,12 +195,12 @@ struct
           newTab tab (fn inner =>
             let
               fun showOne (delim, elem) =
-                at inner
+                goto inner
                 ++ token delim (** this is an '=' *)
                 ++ token (MaybeLongToken.getToken elem)
 
               val first =
-                at inner ++ token (MaybeLongToken.getToken (Seq.nth elems 0))
+                goto inner ++ token (MaybeLongToken.getToken (Seq.nth elems 0))
 
               val stuff =
                 Seq.iterate op++
@@ -208,7 +208,7 @@ struct
                   (Seq.zipWith showOne (delims, Seq.drop elems 1))
             in
               showSpec tab spec
-              ++ at tab
+              ++ goto tab
               ++ token sharingg
               ++ stuff
             end)
@@ -217,12 +217,12 @@ struct
           newTab tab (fn inner =>
             let
               fun showOne (delim, elem) =
-                at inner
+                goto inner
                 ++ token delim (** this is an '=' *)
                 ++ token (MaybeLongToken.getToken elem)
 
               val first =
-                at inner ++ token (MaybeLongToken.getToken (Seq.nth elems 0))
+                goto inner ++ token (MaybeLongToken.getToken (Seq.nth elems 0))
 
               val stuff =
                 Seq.iterate op++
@@ -230,7 +230,7 @@ struct
                   (Seq.zipWith showOne (delims, Seq.drop elems 1))
             in
               showSpec tab spec
-              ++ at tab
+              ++ goto tab
               ++ token sharingg
               ++ token typee
               ++ stuff
@@ -242,7 +242,7 @@ struct
           ++ token left_id
           ++ token eq
           ++ newTab tab (fn inner =>
-              at inner
+              goto inner
               ++ token right_datatypee
               ++ token (MaybeLongToken.getToken right_id))
 
@@ -262,15 +262,15 @@ struct
       | Spec {sigg, spec, endd} =>
           newTabWithStyle tab (Indented, fn inner =>
             token sigg
-            ++ at inner
+            ++ goto inner
             ++ showSpec inner spec
-            ++ cond inner {inactive = empty, active = at tab}
+            ++ cond inner {inactive = empty, active = goto tab}
             ++ token endd)
 
       | WhereType {sigexp, elems} =>
           let
             fun showElem {wheree, typee, tyvars, tycon, eq, ty} =
-              at tab
+              goto tab
               ++ token wheree (** this could be 'and' *)
               ++ token typee
               ++ showSyntaxSeq token tab tyvars
@@ -288,12 +288,12 @@ struct
   and showSigDec tab (Ast.Sig.Signature {signaturee, elems, delims}) =
     let
       fun showOne first (starter, {ident, eq, sigexp}) =
-        (if first then empty else at tab)
+        (if first then empty else goto tab)
         ++ token starter
         ++ token ident
         ++ token eq
         ++ (if sigExpWantsSameTabAsDec sigexp then
-              at tab ++ showSigExp tab sigexp
+              goto tab ++ showSigExp tab sigexp
             else
               withNewChild showSigExp tab sigexp)
     in

--- a/src/prettier-print/PrettierStr.sml
+++ b/src/prettier-print/PrettierStr.sml
@@ -91,17 +91,17 @@ struct
       case e of
         Ident id =>
           token (MaybeLongToken.getToken id)
-          (* newTab tab (fn tab => at tab ++ ) *)
+          (* newTab tab (fn tab => goto tab ++ ) *)
 
       | Struct {structt, strdec, endd} =>
           if decIsEmpty strdec then
-            token structt ++ at tab ++ token endd
+            token structt ++ goto tab ++ token endd
           else
             newTabWithStyle tab (Indented, fn inner =>
               token structt
-              ++ at inner
+              ++ goto inner
               ++ showStrDec inner strdec
-              ++ cond inner {inactive = empty, active = at tab}
+              ++ cond inner {inactive = empty, active = goto tab}
               ++ token endd)
 
       | Constraint {strexp, colon, sigexp} =>
@@ -122,7 +122,7 @@ struct
                space
              else
                nospace) ++
-            at inner ++ token lparen ++ nospace ++
+            goto inner ++ token lparen ++ nospace ++
             withNewChild showStrExp inner strexp
             ++ nospace ++ token rparen)
 
@@ -134,7 +134,7 @@ struct
                space
              else
                nospace) ++
-            at inner ++ token lparen ++ nospace ++
+            goto inner ++ token lparen ++ nospace ++
             withNewChild showStrDec inner strdec
             ++ nospace ++ token rparen)
 
@@ -174,7 +174,7 @@ struct
                      nospace)
                   ++ token colon
                   ++ (if sigExpWantsSameTabAsDec sigexp then
-                        at tab ++ showSigExp tab sigexp
+                        goto tab ++ showSigExp tab sigexp
                       else
                         withNewChild showSigExp tab sigexp)
 
@@ -184,14 +184,14 @@ struct
               ++ showConstraint constraint
               ++ token eq
               ++ (if strExpWantsSameTabAsDec strexp then
-                    at tab ++ showStrExp tab strexp
+                    goto tab ++ showStrExp tab strexp
                   else
                     withNewChild showStrExp tab strexp)
           in
-            at tab ++
+            goto tab ++
             Seq.iterate op++
               (showOne (structuree, Seq.nth elems 0))
-              (Seq.map (fn x => at tab ++ showOne x)
+              (Seq.map (fn x => goto tab ++ showOne x)
                 (Seq.zip (delims, (Seq.drop elems 1))))
           end)
 
@@ -199,7 +199,7 @@ struct
       | DecMultiple {elems, delims} =>
           let
             fun mk first (elem, delim) =
-              (if first then empty else at tab)
+              (if first then empty else goto tab)
               ++ showStrDec tab elem
               ++ showOption (fn d => nospace ++ token d) delim
 
@@ -227,18 +227,18 @@ struct
           newTab tab (fn inner =>
             let
               val front =
-                at inner
+                goto inner
                 ++ token underscore ++ nospace ++ token overload
                 ++ token prec
                 ++ token name
                 ++ token colon
                 ++ withNewChild showTy inner ty
-                ++ at inner
+                ++ goto inner
                 ++ token ass
                 ++ token (MaybeLongToken.getToken (Seq.nth elems 0))
 
               fun showOne (d, e) =
-                at inner ++ token d ++ token (MaybeLongToken.getToken e)
+                goto inner ++ token d ++ token (MaybeLongToken.getToken e)
             in
               Seq.iterate op++
                 front

--- a/src/prettier-print/PrettierStr.sml
+++ b/src/prettier-print/PrettierStr.sml
@@ -91,18 +91,18 @@ struct
       case e of
         Ident id =>
           token (MaybeLongToken.getToken id)
-          (* newTab tab (fn tab => goto tab ++ ) *)
 
       | Struct {structt, strdec, endd} =>
           if decIsEmpty strdec then
-            token structt ++ goto tab ++ token endd
+            token structt ++ at tab (token endd)
           else
             newTabWithStyle tab (Indented, fn inner =>
               token structt
-              ++ goto inner
-              ++ showStrDec inner strdec
-              ++ cond inner {inactive = empty, active = goto tab}
-              ++ token endd)
+              ++ at inner (showStrDec inner strdec)
+              ++ cond inner
+                { inactive = token endd
+                , active = at tab (token endd)
+                })
 
       | Constraint {strexp, colon, sigexp} =>
           showStrExp tab strexp
@@ -122,9 +122,10 @@ struct
                space
              else
                nospace) ++
-            goto inner ++ token lparen ++ nospace ++
-            withNewChild showStrExp inner strexp
-            ++ nospace ++ token rparen)
+            at inner
+              (token lparen ++ nospace
+              ++ withNewChild showStrExp inner strexp
+              ++ nospace ++ token rparen))
 
       | FunAppDec {funid, lparen, strdec, rparen} =>
           (* See note above, about the maybe-space after `funid` *)
@@ -134,9 +135,10 @@ struct
                space
              else
                nospace) ++
-            goto inner ++ token lparen ++ nospace ++
-            withNewChild showStrDec inner strdec
-            ++ nospace ++ token rparen)
+            at inner
+              (token lparen ++ nospace
+              ++ withNewChild showStrDec inner strdec
+              ++ nospace ++ token rparen))
 
       | LetInEnd {lett, strdec, inn, strexp, endd} =>
           showThingSimilarToLetInEnd tab
@@ -174,7 +176,7 @@ struct
                      nospace)
                   ++ token colon
                   ++ (if sigExpWantsSameTabAsDec sigexp then
-                        goto tab ++ showSigExp tab sigexp
+                        at tab (showSigExp tab sigexp)
                       else
                         withNewChild showSigExp tab sigexp)
 
@@ -184,24 +186,23 @@ struct
               ++ showConstraint constraint
               ++ token eq
               ++ (if strExpWantsSameTabAsDec strexp then
-                    goto tab ++ showStrExp tab strexp
+                    at tab (showStrExp tab strexp)
                   else
                     withNewChild showStrExp tab strexp)
           in
-            goto tab ++
-            Seq.iterate op++
+            at tab (Seq.iterate op++
               (showOne (structuree, Seq.nth elems 0))
-              (Seq.map (fn x => goto tab ++ showOne x)
-                (Seq.zip (delims, (Seq.drop elems 1))))
+              (Seq.map (fn x => at tab (showOne x))
+                (Seq.zip (delims, (Seq.drop elems 1)))))
           end)
 
 
       | DecMultiple {elems, delims} =>
           let
             fun mk first (elem, delim) =
-              (if first then empty else goto tab)
-              ++ showStrDec tab elem
-              ++ showOption (fn d => nospace ++ token d) delim
+              maybeAt tab (not first)
+                (showStrDec tab elem
+                ++ showOption (fn d => nospace ++ token d) delim)
 
             val things = Seq.zip (elems, delims)
           in
@@ -227,18 +228,19 @@ struct
           newTab tab (fn inner =>
             let
               val front =
-                goto inner
-                ++ token underscore ++ nospace ++ token overload
-                ++ token prec
-                ++ token name
-                ++ token colon
+                at inner
+                  (token underscore ++ nospace ++ token overload
+                  ++ token prec
+                  ++ token name
+                  ++ token colon)
                 ++ withNewChild showTy inner ty
-                ++ goto inner
-                ++ token ass
-                ++ token (MaybeLongToken.getToken (Seq.nth elems 0))
+                ++
+                at inner
+                  (token ass
+                  ++ token (MaybeLongToken.getToken (Seq.nth elems 0)))
 
               fun showOne (d, e) =
-                goto inner ++ token d ++ token (MaybeLongToken.getToken e)
+                at inner (token d ++ token (MaybeLongToken.getToken e))
             in
               Seq.iterate op++
                 front

--- a/src/prettier-print/PrettierTy.sml
+++ b/src/prettier-print/PrettierTy.sml
@@ -59,7 +59,7 @@ struct
       | Arrow {from, arrow, to} =>
           let
             fun loop (arr, right) =
-              at tab ++ token arr ++
+              goto tab ++ token arr ++
               (case right of
                 Arrow {from, arrow, to} =>
                   withNewChild showTy tab from

--- a/src/prettier-print/PrettierTy.sml
+++ b/src/prettier-print/PrettierTy.sml
@@ -59,13 +59,13 @@ struct
       | Arrow {from, arrow, to} =>
           let
             fun loop (arr, right) =
-              goto tab ++ token arr ++
-              (case right of
-                Arrow {from, arrow, to} =>
-                  withNewChild showTy tab from
-                  ++ loop (arrow, to)
-              | _ =>
-                  withNewChild showTy tab right)
+              at tab (token arr ++
+                (case right of
+                  Arrow {from, arrow, to} =>
+                    withNewChild showTy tab from
+                    ++ loop (arrow, to)
+                | _ =>
+                    withNewChild showTy tab right))
           in
             withNewChild showTy tab from ++ loop (arrow, to)
           end

--- a/src/prettier-print/PrettierUtil.sml
+++ b/src/prettier-print/PrettierUtil.sml
@@ -9,7 +9,6 @@ sig
   type doc = TabbedTokenDoc.doc
   type style = TabbedTokenDoc.style
 
-  val at: tab -> doc -> doc
   val maybeAt: tab -> bool -> doc -> doc
 
   type 'a shower = tab -> 'a -> doc
@@ -46,8 +45,6 @@ struct
   open TabbedTokenDoc
   infix 2 ++
   fun x ++ y = concat (x, y)
-
-  fun at tab doc = goto tab ++ doc
 
   fun maybeAt tab b doc =
     if b then at tab doc else doc

--- a/src/prettier-print/PrettierUtil.sml
+++ b/src/prettier-print/PrettierUtil.sml
@@ -48,10 +48,10 @@ struct
   type 'a shower = tab -> 'a -> doc
 
   fun withNewChild shower tab x =
-    newTab tab (fn inner => at inner ++ shower inner x)
+    newTab tab (fn inner => goto inner ++ shower inner x)
 
   fun withNewChildWithStyle style shower tab x =
-    newTabWithStyle tab (style, fn inner => at inner ++ shower inner x)
+    newTabWithStyle tab (style, fn inner => goto inner ++ shower inner x)
 
 
   fun spaces n =
@@ -64,11 +64,11 @@ struct
     else
       let
         val top = token openn ++ (cond tab {inactive = nospace, active = space}) ++ Seq.nth elems 0
-        fun f (delim, x) = nospace ++ at tab ++ token delim ++ x
+        fun f (delim, x) = nospace ++ goto tab ++ token delim ++ x
       in
         Seq.iterate op++ top (Seq.map f (Seq.zip (delims, Seq.drop elems 1)))
         ++
-        nospace ++ at tab ++ token close
+        nospace ++ goto tab ++ token close
       end
 
 
@@ -97,10 +97,10 @@ struct
       (if isEmpty1 then
           empty
         else
-          doc1 ++ at tab)
+          doc1 ++ goto tab)
       ++ token inn
       ++ doc2
-      ++ at tab ++ token endd
+      ++ goto tab ++ token endd
     end
 
 

--- a/src/prettier-print/PrettierUtil.sml
+++ b/src/prettier-print/PrettierUtil.sml
@@ -68,6 +68,10 @@ struct
   fun showSequence tab {openn, elems, delims, close} =
     if Seq.length elems = 0 then
       token openn ++ nospace ++ token close
+    else if Seq.length elems = 1 then
+      token openn ++ nospace
+      ++ Seq.nth elems 0
+      ++ nospace ++ token close
     else
       let
         val top = token openn ++ (cond tab {inactive = nospace, active = space}) ++ Seq.nth elems 0

--- a/src/prettier-print/TabbedTokenDoc.sml
+++ b/src/prettier-print/TabbedTokenDoc.sml
@@ -760,7 +760,7 @@ struct
             Seq.iterate
               D.concat
               D.empty
-              (Seq.map (fn x => D.concat (D.goto tab, x)) pieces))
+              (Seq.map (fn x => D.at tab x) pieces))
         )
     end
 
@@ -805,14 +805,10 @@ struct
 
               val (shouldBeRigid, doc) = tokenToStringDoc tab tabWidth tok
             in
-              (* TODO: rigidity (don't allow flattening) *)
               doc
             end
         | AnnAt {tab, doc, ...} =>
-            D.concat
-              ( D.goto (TabDict.lookup tabmap tab)
-              , loop currentTab tabmap doc
-              )
+            D.at (TabDict.lookup tabmap tab) (loop currentTab tabmap doc)
         | AnnCond {tab, inactive, active} =>
             D.cond (TabDict.lookup tabmap tab)
               { inactive = loop currentTab tabmap inactive


### PR DESCRIPTION
Previously we had a primitive `at: tab -> doc`, which we now realize is more aptly named `goto`. This primitive is, frankly, strange to reason about when designing output formats.

This patch removes `at: tab -> doc` and replaces it with `at: tab -> doc -> doc`, where `at t d` places the document `d` beginning at the tab `t`. The precondition (not yet checked automatically) is that `d` should only mention `t` or its descendants; in this way, the formatting of `d` should be context independent, making it easier to reason about resulting layouts. I have a suspicion that this will lead to a more efficient layout algorithm, but that remains to be seen.