### PR TITLE
WIP: add doc vars

### DIFF
--- a/src/base/DocVar.sml
+++ b/src/base/DocVar.sml
@@ -1,0 +1,32 @@
+(** Copyright (c) 2022 Sam Westrick
+  *
+  * See the file LICENSE for details.
+  *)
+
+structure DocVar:
+sig
+  type t
+  val new: unit -> t
+  val toString: t -> string
+  val compare: t * t -> order
+end =
+struct
+
+  datatype t = DocVar of {id: int}
+
+  val counter = ref 0
+
+  fun new () =
+    let
+      val result = DocVar {id = !counter}
+    in
+      counter := !counter + 1;
+      result
+    end
+
+  fun toString (DocVar {id}) = "[v" ^ Int.toString id ^ "]"
+
+  fun compare (DocVar {id=id1}, DocVar {id=id2}) =
+    Int.compare (id1, id2)
+
+end

--- a/src/base/PrettyTabbedDoc.sml
+++ b/src/base/PrettyTabbedDoc.sml
@@ -677,6 +677,10 @@ struct
 
   fun pretty {ribbonFrac, maxWidth, indentWidth, debug} doc =
     let
+      fun dbgprintln s =
+        if not debug then ()
+        else print (s ^ "\n")
+
       val ribbonWidth =
         Int.max (0, Int.min (maxWidth,
           Real.round (ribbonFrac * Real.fromInt maxWidth)))
@@ -1101,7 +1105,7 @@ struct
         if not debug then items
         else Item.EndDebug (EndTabHighlight {tab = Tab.Root, col = 0}) :: items
 
-      val _ = print ("layout: " ^ Time.fmt 3 tm ^ "s\n")
+      val _ = dbgprintln ("layout: " ^ Time.fmt 3 tm ^ "s\n")
 
       val items = if not debug then items else implementDebugs maxWidth items
 

--- a/src/base/PrettyTabbedDoc.sml
+++ b/src/base/PrettyTabbedDoc.sml
@@ -1095,10 +1095,13 @@ struct
 
       val init = LS (TabDict.empty, root, TabSet.singleton root, 0, 0, [])
       val init = dbgBreak Tab.Root (dbgInsert Tab.Root init)
-      val LS (_, _, _, _, _, items) = layout init doc
+      val (LS (_, _, _, _, _, items), tm) =
+        Util.getTime (fn _ => layout init doc)
       val items =
         if not debug then items
         else Item.EndDebug (EndTabHighlight {tab = Tab.Root, col = 0}) :: items
+
+      val _ = print ("layout: " ^ Time.fmt 3 tm ^ "s\n")
 
       val items = if not debug then items else implementDebugs maxWidth items
 

--- a/src/base/sources.mlb
+++ b/src/base/sources.mlb
@@ -25,5 +25,7 @@ end
 
 Set.sml
 
+DocVar.sml
+
 PrettySimpleDoc.sml
 PrettyTabbedDoc.sml

--- a/src/prettier-print/PrettierExpAndDec.sml
+++ b/src/prettier-print/PrettierExpAndDec.sml
@@ -491,38 +491,47 @@ struct
                 , active = at alignedArgsTab (showExp alignedArgsTab arg)
                 }
           in
-            cond allArgsGhost
-              { inactive = at allArgsGhost contents
-              , active = contents
-              }
+            letdoc contents (fn c =>
+              cond allArgsGhost
+                { inactive = at allArgsGhost (var c)
+                , active = var c
+                })
           end)
 
       fun makeLastArg alignedArgsTab allArgsGhost arg =
         newTab tab (fn ghost1 =>
         newTab tab (fn ghost2 =>
           let
-            val contents =
+            val aligned =
+              at alignedArgsTab (showExp alignedArgsTab arg)
+
+            val flat =
+              at ghost2 (showExp ghost2 arg)
+
+            fun contents f a =
               cond ghost1
                 { inactive =
                     cond ghost2
-                      { inactive = at ghost2 (showExp ghost2 arg)
+                      { inactive = var f
                       , active =
                           at ghost1 (splitShowExpLeft ghost1 arg)
                           ++
                           at alignedArgsTab (splitShowExpRight alignedArgsTab arg)
                       }
 
-                , active = at alignedArgsTab (showExp alignedArgsTab arg)
+                , active = var a
                 }
           in
-            cond allArgsGhost
-              { inactive = contents
-              , active =
-                  cond ghost1
-                    { inactive = at ghost1 (showExp ghost1 arg)
-                    , active = at alignedArgsTab (showExp alignedArgsTab arg)
-                    }
-              }
+            letdoc aligned (fn a =>
+            letdoc flat (fn f =>
+              cond allArgsGhost
+                { inactive = contents f a
+                , active =
+                    cond ghost2
+                      { inactive = var f
+                      , active = var a
+                      }
+                }))
           end))
     in
       newTab tab (fn alignedArgsTab =>


### PR DESCRIPTION
**(Work-in-progress. Not ready to merge.)**

### Overview

The goal of this patch is to improve performance by decreasing document "code size". This is motivated by recent updates (88d32c9e6e4ab7f7792e8011d82ff059ab0ceea2 ... 95d285aa5c027103e8caa59d398e244e68152c39) which implemented splittable arguments. The details of splittable arguments don't matter here, but one effect of those changes was that the size of the document generated by the pretty printer increased significantly due to duplication of document descriptions across conditional branches.

The increased document size is very costly: on source code of ~1K lines, `smlfmt` was taking as many as 3-5 minutes to complete.

### Document "code size" blowup example

Here's an example, where we use a "ghost" tab to conditionally place the document `D` either inline or at `otherTab`. This results in `D` being duplicated across the branches.
```sml
let
  val D = ...
in
  cond ghost
    { inactive = at ghost D
    , active = at otherTab D
    }
end
```

### New primitives: doc variables

To fix this, we introduce two new primitives which allow us to bind documents to variables and later use those documents:
```sml
type docvar
val letdoc: doc -> (docvar -> doc) -> doc
val var: docvar -> doc
```

The example above can then be rewritten with no duplication:
```sml
let
  val D = ...
in
  letdoc D (fn x =>
    cond ghost
      { inactive = at ghost (var x)
      , active = at otherTab (var x)
      }
end
```

From initial experiments, this significantly improves running time, bringing the time of `smlfmt` on 1K lines of source code down to ~3 seconds.