### PR TITLE
Pull out `Tab` structure

### DIFF
--- a/src/base/PrettyTabbedDoc.sml
+++ b/src/base/PrettyTabbedDoc.sml
@@ -36,15 +36,9 @@ sig
   val text: CustomString.t -> doc
   val concat: doc * doc -> doc
 
-  datatype style =
-    Inplace
-  | Indented of {minIndent: int} option
-  | RigidInplace
-  | RigidIndented of {minIndent: int} option
-
   type tab
   val root: tab
-  val newTab: tab -> style * (tab -> doc) -> doc
+  val newTab: tab -> Tab.Style.t * (tab -> doc) -> doc
   val at: tab -> doc -> doc
   val cond: tab -> {inactive: doc, active: doc} -> doc
 
@@ -67,19 +61,11 @@ struct
 
   (* ====================================================================== *)
 
-
-  datatype style =
-    Inplace
-  | Indented of {minIndent: int} option
-  | RigidInplace
-  | RigidIndented of {minIndent: int} option
-
-
   structure Tab =
   struct
 
     datatype tab =
-      Tab of {id: int, style: style, parent: tab}
+      Tab of {id: int, style: Tab.Style.t, parent: tab}
     | Root
 
     type t = tab
@@ -106,25 +92,25 @@ struct
 
     fun style t =
       case t of
-        Root => Inplace
+        Root => Tab.Style.Inplace
       | Tab {style=s, ...} => s
 
     fun isRigid t =
       case style t of
-        RigidInplace => true
-      | RigidIndented _ => true
+        Tab.Style.RigidInplace => true
+      | Tab.Style.RigidIndented _ => true
       | _ => false
 
     fun isInplace t =
       case style t of
-        RigidInplace => true
-      | Inplace => true
+        Tab.Style.RigidInplace => true
+      | Tab.Style.Inplace => true
       | _ => false
 
     fun minIndent t =
       case style t of
-        Indented (SOME {minIndent=i}) => i
-      | RigidIndented (SOME {minIndent=i}) => i
+        Tab.Style.Indented (SOME {minIndent=i}) => i
+      | Tab.Style.RigidIndented (SOME {minIndent=i}) => i
       | _ => 0
 
     fun parent t =

--- a/src/base/Tab.sml
+++ b/src/base/Tab.sml
@@ -25,8 +25,16 @@ sig
 
   val parent: tab -> tab option
   val style: tab -> Style.t
+  val depth: tab -> int
+
+  val eq: tab * tab -> bool
   val compare: tab * tab -> order
 
+  val minIndent: tab -> int
+  val isInplace: tab -> bool
+  val isRigid: tab -> bool
+
+  val name: tab -> string
   val toString: tab -> string
 
 end =
@@ -76,10 +84,13 @@ struct
       Root => Style.Inplace
     | Tab {style=s, ...} => s
 
-  fun toString t =
+  fun name t =
     case t of
-      Tab {id=c, ...} => "[" ^ Int.toString c ^ "]"
-    | Root => "[root]"
+      Root => "root"
+    | Tab {id=c, ...} => Int.toString c
+
+  fun toString t =
+    "[" ^ name t ^ "]"
 
   fun compare (t1: tab, t2: tab) : order =
     case (t1, t2) of
@@ -87,5 +98,31 @@ struct
     | (Tab t1, Tab t2) => Int.compare (#id t1, #id t2)
     | (Tab _, Root) => GREATER
     | (Root, Tab _) => LESS
+
+  fun eq (t1, t2) =
+    compare (t1, t2) = EQUAL
+
+  fun depth t =
+    case t of
+      Root => 0
+    | Tab {parent=p, ...} => 1 + depth p
+
+  fun isRigid t =
+    case style t of
+      Style.RigidInplace => true
+    | Style.RigidIndented _ => true
+    | _ => false
+
+  fun isInplace t =
+    case style t of
+      Style.RigidInplace => true
+    | Style.Inplace => true
+    | _ => false
+
+  fun minIndent t =
+    case style t of
+      Style.Indented (SOME {minIndent=i}) => i
+    | Style.RigidIndented (SOME {minIndent=i}) => i
+    | _ => 0
 
 end

--- a/src/base/Tab.sml
+++ b/src/base/Tab.sml
@@ -1,0 +1,91 @@
+(** Copyright (c) 2022 Sam Westrick
+  *
+  * See the file LICENSE for details.
+  *)
+
+structure Tab:
+sig
+
+  structure Style:
+  sig
+    datatype style =
+      Inplace
+    | Indented of {minIndent: int} option
+    | RigidInplace
+    | RigidIndented of {minIndent: int} option
+
+    type t = style
+  end
+
+  type tab
+  type t = tab
+
+  val root: tab
+  val new: {parent: tab, style: Style.t} -> tab
+
+  val parent: tab -> tab option
+  val style: tab -> Style.t
+  val compare: tab * tab -> order
+
+  val toString: tab -> string
+
+end =
+struct
+
+  (* ===================================================================== *)
+
+  structure Style =
+  struct
+    datatype style =
+      Inplace
+    | Indented of {minIndent: int} option
+    | RigidInplace
+    | RigidIndented of {minIndent: int} option
+
+    type t = style
+  end
+
+  (* ===================================================================== *)
+
+
+  datatype tab =
+    Tab of {id: int, style: Style.t, parent: tab}
+  | Root
+
+  type t = tab
+
+  val tabCounter = ref 0
+
+  fun new {parent, style} =
+    let
+      val c = !tabCounter
+    in
+      tabCounter := c+1;
+      Tab {id = c, style = style, parent = parent}
+    end
+
+  val root = Root
+
+  fun parent t =
+    case t of
+      Root => NONE
+    | Tab {parent, ...} => SOME parent
+
+  fun style t =
+    case t of
+      Root => Style.Inplace
+    | Tab {style=s, ...} => s
+
+  fun toString t =
+    case t of
+      Tab {id=c, ...} => "[" ^ Int.toString c ^ "]"
+    | Root => "[root]"
+
+  fun compare (t1: tab, t2: tab) : order =
+    case (t1, t2) of
+      (Root, Root) => EQUAL
+    | (Tab t1, Tab t2) => Int.compare (#id t1, #id t2)
+    | (Tab _, Root) => GREATER
+    | (Root, Tab _) => LESS
+
+end

--- a/src/base/sources.mlb
+++ b/src/base/sources.mlb
@@ -26,6 +26,7 @@ end
 Set.sml
 
 DocVar.sml
+Tab.sml
 
 PrettySimpleDoc.sml
 PrettyTabbedDoc.sml

--- a/src/prettier-print/PrettierExpAndDec.sml
+++ b/src/prettier-print/PrettierExpAndDec.sml
@@ -318,7 +318,7 @@ struct
                 ++ showBranch inner1 branch)
 
             val style =
-              if Seq.length elems <= 1 then Inplace else RigidInplace
+              if Seq.length elems <= 1 then Tab.Style.Inplace else Tab.Style.RigidInplace
           in
             newTabWithStyle tab (style, fn inner1 =>
             newTab inner1 (fn inner2 =>
@@ -864,12 +864,12 @@ struct
         let
           val clauseChildStyle =
             if Seq.length innerElems <= 1 then
-              Inplace
+              Tab.Style.Inplace
             else
               indentedAtLeastBy 6
         in
           at tab (
-            newTabWithStyle tab (RigidInplace, fn tab =>
+            newTabWithStyle tab (Tab.Style.RigidInplace, fn tab =>
               Seq.iterate op++
                 (showClause tab true clauseChildStyle (starter, Seq.nth innerElems 0))
                 (Seq.zipWith (showClause tab false clauseChildStyle)

--- a/src/prettier-print/PrettierUtil.sml
+++ b/src/prettier-print/PrettierUtil.sml
@@ -7,7 +7,7 @@ structure PrettierUtil:
 sig
   type tab = TabbedTokenDoc.tab
   type doc = TabbedTokenDoc.doc
-  type style = TabbedTokenDoc.style
+  type style = Tab.Style.t
 
   val indented: style
   val indentedAtLeastBy: int -> style
@@ -55,9 +55,9 @@ struct
   infix 2 ++
   fun x ++ y = concat (x, y)
 
-  val indented = Indented NONE
+  val indented = Tab.Style.Indented NONE
 
-  fun indentedAtLeastBy x = Indented (SOME {minIndent=x})
+  fun indentedAtLeastBy x = Tab.Style.Indented (SOME {minIndent=x})
 
   type 'a shower = tab -> 'a -> doc
 

--- a/src/prettier-print/TabbedTokenDoc.sml
+++ b/src/prettier-print/TabbedTokenDoc.sml
@@ -17,11 +17,7 @@ sig
   val letdoc: doc -> (DocVar.t -> doc) -> doc
   val var: DocVar.t -> doc
 
-  datatype style =
-    Inplace
-  | Indented of {minIndent: int} option
-  | RigidInplace
-  | RigidIndented of {minIndent: int} option
+  type style = Tab.Style.t
 
   type tab
   val root: tab
@@ -36,62 +32,13 @@ struct
 
   structure D = TabbedStringDoc
 
-  datatype style =
-    Inplace
-  | Indented of {minIndent: int} option
-  | RigidInplace
-  | RigidIndented of {minIndent: int} option
+  type tab = Tab.t
+  type style = Tab.Style.t
 
-  (* Just need a unique name *)
-  datatype tab =
-    Tab of {id: int, style: style, parent: tab}
-  | Root
+  val root = Tab.root
 
-  val tabCounter = ref 0
-
-  fun mkTab parent style =
-    let
-      val c = !tabCounter
-    in
-      tabCounter := c+1;
-      Tab {id = c, style = style, parent = parent}
-    end
-
-
-  val root = Root
-
-
-  fun parent t =
-    case t of
-      Root => NONE
-    | Tab {parent, ...} => SOME parent
-
-
-  fun style t =
-    case t of
-      Root => Inplace
-    | Tab {style=s, ...} => s
-
-
-  fun tabToString t =
-    case t of
-      Tab {id=c, ...} => "[" ^ Int.toString c ^ "]"
-    | Root => "[root]"
-
-
-  structure TabKey =
-  struct
-    type t = tab
-    fun compare (t1: tab, t2: tab) : order =
-      case (t1, t2) of
-        (Root, Root) => EQUAL
-      | (Tab t1, Tab t2) => Int.compare (#id t1, #id t2)
-      | (Tab _, Root) => GREATER
-      | (Root, Tab _) => LESS
-  end
-
-  structure TabDict = Dict(TabKey)
-  structure TabSet = Set(TabKey)
+  structure TabDict = Dict(Tab)
+  structure TabSet = Set(Tab)
   structure VarDict = Dict(DocVar)
 
   datatype doc =
@@ -133,10 +80,10 @@ struct
     | Concat (d1, d2) => toString d1 ^ " ++ " ^ toString d2
     | Token t => "Token('" ^ Token.toString t ^ "')"
     | Text t => "Text('" ^ t ^ "')"
-    | At (t, d) => "At(" ^ tabToString t ^ "," ^ toString d ^ ")"
-    | NewTab {tab=t, doc=d, ...} => "NewTab(" ^ tabToString t ^ ", " ^ toString d ^ ")"
+    | At (t, d) => "At(" ^ Tab.toString t ^ "," ^ toString d ^ ")"
+    | NewTab {tab=t, doc=d, ...} => "NewTab(" ^ Tab.toString t ^ ", " ^ toString d ^ ")"
     | Cond {tab=t, inactive=df, active=dnf} =>
-        "Cond(" ^ tabToString t ^ ", " ^ toString df ^ ", " ^ toString dnf ^ ")"
+        "Cond(" ^ Tab.toString t ^ ", " ^ toString df ^ ", " ^ toString dnf ^ ")"
     | LetDoc {var, doc=d, inn} =>
         "LetDoc(" ^ DocVar.toString var ^ ", " ^ toString d ^ ", " ^ toString inn ^ ")"
     | Var v =>
@@ -152,13 +99,13 @@ struct
 
   fun newTabWithStyle parent (style, genDocUsingTab: tab -> doc) =
     let
-      val t = mkTab parent style
+      val t = Tab.new {parent=parent, style=style}
       val d = genDocUsingTab t
     in
       NewTab {tab=t, doc=d}
     end
 
-  fun newTab parent f = newTabWithStyle parent (Inplace, f)
+  fun newTab parent f = newTabWithStyle parent (Tab.Style.Inplace, f)
 
   (* ====================================================================== *)
   (* ====================================================================== *)
@@ -189,10 +136,10 @@ struct
     | AnnToken {tok=t, ...} => "Token('" ^ Token.toString t ^ "')"
     | AnnText {txt=t, ...} => "Text('" ^ t ^ "')"
     | AnnAt {tab, doc} =>
-        "At(" ^ tabToString tab ^ ", " ^ annToString doc ^ ")"
-    | AnnNewTab {tab=t, doc=d, ...} => "NewTab(" ^ tabToString t ^ ", " ^ annToString d ^ ")"
+        "At(" ^ Tab.toString tab ^ ", " ^ annToString doc ^ ")"
+    | AnnNewTab {tab=t, doc=d, ...} => "NewTab(" ^ Tab.toString t ^ ", " ^ annToString d ^ ")"
     | AnnCond {tab=t, inactive=df, active=dnf} =>
-        "Cond(" ^ tabToString t ^ ", " ^ annToString df ^ ", " ^ annToString dnf ^ ")"
+        "Cond(" ^ Tab.toString t ^ ", " ^ annToString df ^ ", " ^ annToString dnf ^ ")"
     | AnnLetDoc {var, doc=d, inn} =>
         "LetDoc(" ^ DocVar.toString var ^ ", " ^ annToString d ^ ", " ^ annToString inn ^ ")"
     | AnnVar v =>
@@ -359,10 +306,10 @@ struct
         TabDict.insert ctx (tab, Inactive)
 
       fun markActive ctx tab =
-        case tab of
-          Root => ctx
-        | Tab {parent, ...} =>
-            markActive (TabDict.insert ctx (tab, Active)) parent
+        case Tab.parent tab of
+          NONE => ctx
+        | SOME p =>
+            markActive (TabDict.insert ctx (tab, Active)) p
 
       fun flowunion (flow1, flow2) =
         case (flow1, flow2) of
@@ -382,7 +329,7 @@ struct
                 Option.app (fn ts =>
                   dbgprintln
                     ("token '" ^ Token.toString tok ^ "' at: " ^
-                     String.concatWith " " (List.map tabToString (TabSet.listKeys ts))))
+                     String.concatWith " " (List.map Tab.toString (TabSet.listKeys ts))))
                 flowval
             in
               (NONE, vars, AnnToken {tok=tok, at=flowval})
@@ -393,7 +340,7 @@ struct
                 Option.app (fn ts =>
                   dbgprintln
                     ("text '" ^ txt ^ "' at: " ^
-                     String.concatWith " " (List.map tabToString (TabSet.listKeys ts))))
+                     String.concatWith " " (List.map Tab.toString (TabSet.listKeys ts))))
                 flowval
             in
               (NONE, vars, AnnText {txt=txt, at=flowval})
@@ -449,7 +396,7 @@ struct
             end
 
       val (_, varinfo, doc) =
-        loop TabDict.empty (SOME (TabSet.singleton Root), VarDict.empty, doc)
+        loop TabDict.empty (SOME (TabSet.singleton root), VarDict.empty, doc)
 
       fun updateVars doc =
         case doc of
@@ -763,14 +710,14 @@ struct
         | AnnNewTab {tab, doc} =>
             let
               val s =
-                case style tab of
-                  Inplace => D.Inplace
-                | Indented xx => D.Indented xx
-                | RigidInplace => D.RigidInplace
-                | RigidIndented xx => D.RigidIndented xx
+                case Tab.style tab of
+                  Tab.Style.Inplace => D.Inplace
+                | Tab.Style.Indented xx => D.Indented xx
+                | Tab.Style.RigidInplace => D.RigidInplace
+                | Tab.Style.RigidIndented xx => D.RigidIndented xx
             in
               D.newTab
-                (TabDict.lookup tabmap (valOf (parent tab)))
+                (TabDict.lookup tabmap (valOf (Tab.parent tab)))
                 (s, fn tab' =>
                   loop tab' (TabDict.insert tabmap (tab, tab')) vars doc)
             end
@@ -785,7 +732,7 @@ struct
             VarDict.lookup vars v
 
       val (result, tm) = Util.getTime (fn _ =>
-        loop D.root (TabDict.singleton (Root, D.root)) VarDict.empty doc)
+        loop D.root (TabDict.singleton (root, D.root)) VarDict.empty doc)
 
       val _ = dbgprintln ("convert: " ^ Time.fmt 3 tm ^ "s\n")
     in

--- a/src/prettier-print/TabbedTokenDoc.sml
+++ b/src/prettier-print/TabbedTokenDoc.sml
@@ -648,7 +648,7 @@ struct
         (false, D.text t)
       else
         ( true
-        , D.newTab currentTab (D.RigidInplace, fn tab =>
+        , D.newTab currentTab (Tab.Style.RigidInplace, fn tab =>
             Seq.iterate
               D.concat
               D.empty
@@ -708,19 +708,10 @@ struct
               , active = loop currentTab tabmap vars active
               }
         | AnnNewTab {tab, doc} =>
-            let
-              val s =
-                case Tab.style tab of
-                  Tab.Style.Inplace => D.Inplace
-                | Tab.Style.Indented xx => D.Indented xx
-                | Tab.Style.RigidInplace => D.RigidInplace
-                | Tab.Style.RigidIndented xx => D.RigidIndented xx
-            in
-              D.newTab
-                (TabDict.lookup tabmap (valOf (Tab.parent tab)))
-                (s, fn tab' =>
-                  loop tab' (TabDict.insert tabmap (tab, tab')) vars doc)
-            end
+            D.newTab
+              (TabDict.lookup tabmap (valOf (Tab.parent tab)))
+              (Tab.style tab, fn tab' =>
+                loop tab' (TabDict.insert tabmap (tab, tab')) vars doc)
         | AnnLetDoc {var, doc, inn} =>
             let
               val doc' = loop currentTab tabmap vars doc


### PR DESCRIPTION
Reuse tabs across `TabbedTokenDoc` and `PrettyTabbedDoc`, allowing for more efficient conversion between the two, and avoiding duplicated code across the two modules.