### PR TITLE
Allow top level expressions

### DIFF
--- a/src/ast/AstType.sml
+++ b/src/ast/AstType.sml
@@ -912,6 +912,7 @@ struct
     SigDec of Sig.sigdec
   | StrDec of Str.strdec
   | FunDec of Fun.fundec
+  | TopExp of {exp: Exp.exp, semicolon: Token.t}
 
   datatype ast =
     (** optional semicolon after every topdec *)

--- a/src/demo.sml
+++ b/src/demo.sml
@@ -44,7 +44,7 @@ fun doMLB () =
 
     val ast =
       ParseAllSMLFromMLB.parse
-        {skipBasis = skipBasis, pathmap = pathmap}
+        {skipBasis = skipBasis, pathmap = pathmap, allowTopExp = true}
         (FilePath.fromUnixPath infile)
   in
     print "\nParsing succeeded.\n"
@@ -65,7 +65,7 @@ fun dumpToks toks =
 fun doSML () =
   let
     val source = Source.loadFromFile (FilePath.fromUnixPath infile)
-    val ast = Parser.parse source
+    val ast = Parser.parse {allowTopExp = true} source
     val _ =
       if not doPrettySML then
         TerminalColorString.print (SyntaxHighlighter.highlight source)

--- a/src/parse-mlb/ParseAllSMLFromMLB.sml
+++ b/src/parse-mlb/ParseAllSMLFromMLB.sml
@@ -8,7 +8,7 @@ sig
   (** Take an .mlb source and fully parse all SML by loading all filepaths
     * recursively specified by the .mlb and parsing them, etc.
     *)
-  val parse: {pathmap: MLtonPathMap.t, skipBasis: bool}
+  val parse: {pathmap: MLtonPathMap.t, skipBasis: bool, allowTopExp: bool}
           -> FilePath.t
           -> (FilePath.t * Ast.t) Seq.t
 end =
@@ -68,7 +68,7 @@ struct
     TextIO.output (TextIO.stdErr, m)
 
   (** when skipBasis = true, we ignore paths containing $(SML_LIB) *)
-  fun parse {skipBasis, pathmap} mlbPath : (FilePath.t * Ast.ast) Seq.t =
+  fun parse {skipBasis, pathmap, allowTopExp} mlbPath : (FilePath.t * Ast.ast) Seq.t =
     let
       open MLBAst
 
@@ -122,7 +122,7 @@ struct
                 handle OS.SysErr (msg, _) => errFun msg
 
               val (infdict, ast) =
-                Parser.parseWithInfdict (#fixities basis) src
+                Parser.parseWithInfdict {allowTopExp=allowTopExp} (#fixities basis) src
             in
               ({fixities = infdict}, [(path, ast)])
             end

--- a/src/prettier-print/PrettierPrintAst.sml
+++ b/src/prettier-print/PrettierPrintAst.sml
@@ -33,6 +33,9 @@ struct
                 Ast.StrDec d => showStrDec tab d
               | Ast.SigDec d => showSigDec tab d
               | Ast.FunDec d => showFunDec tab d
+              | Ast.TopExp {exp, semicolon} =>
+                  PrettierExpAndDec.showExp tab exp
+                  ++ nospace ++ token semicolon
             val sc =
               case semicolon of
                 NONE => empty

--- a/src/pretty-print/PrettyPrintAst.sml
+++ b/src/pretty-print/PrettyPrintAst.sml
@@ -44,6 +44,11 @@ struct
                 Ast.StrDec d => showStrDec d
               | Ast.SigDec d => showSigDec d
               | Ast.FunDec d => showFunDec d
+              | Ast.TopExp _ =>
+                  raise Fail "unsupported: top-level expressions. Note: you are \
+                             \using `-engine pretty`, which is headed towards \
+                             \deprecation. Please use `-engine prettier` instead, \
+                             \which supports top-level expressions."
             val sc =
               case semicolon of
                 NONE => empty

--- a/src/smlfmt.sml
+++ b/src/smlfmt.sml
@@ -42,6 +42,7 @@ val indentWidth = CommandLineArgs.parseInt "indent-width" 2
 val engine = CommandLineArgs.parseString "engine" "prettier"
 val inputfiles = CommandLineArgs.positional ()
 
+val allowTopExp = CommandLineArgs.parseBool "allow-top-level-exps" true
 val doDebug = CommandLineArgs.parseFlag "debug-engine"
 val doForce = CommandLineArgs.parseFlag "force"
 val doHelp = CommandLineArgs.parseFlag "help"
@@ -182,7 +183,7 @@ fun doSML filepath =
     val fp = FilePath.fromUnixPath filepath
     val source = Source.loadFromFile fp
     val ast =
-      Parser.parse source
+      Parser.parse {allowTopExp = allowTopExp} source
       handle exn => handleLexOrParseError exn
   in
     doSMLAst (fp, ast)
@@ -193,7 +194,7 @@ fun doMLB filepath =
   let
     val fp = FilePath.fromUnixPath filepath
     val asts =
-      ParseAllSMLFromMLB.parse {skipBasis = true, pathmap = pathmap} fp
+      ParseAllSMLFromMLB.parse {skipBasis = true, pathmap = pathmap, allowTopExp = allowTopExp} fp
       handle exn => handleLexOrParseError exn
   in
     Util.for (0, Seq.length asts) (fn i =>


### PR DESCRIPTION
(Fixes #57.)

Compilers like SML/NJ allow for top-level expressions terminated by a semicolon, e.g.:
```sml
use "foo.sml";
fun bar () = ...
```

This patch implements support for top-level expressions in the parser and pretty printer. By default, top-level expressions are allowed. This can be disabled with the command-line arg `-allow-top-level-exps false`, if desired.