### PR TITLE
Fix comments at end of file

### DIFF
--- a/src/base/PrettyTabbedDoc.sml
+++ b/src/base/PrettyTabbedDoc.sml
@@ -1295,6 +1295,22 @@ struct
         end
 
 
+      (* Only intended to be called at the end, to flush any outstanding
+       * comments from the layout state.
+       *)
+      fun flushComments state =
+        let
+          val LS (dbgState, ct, cats, coms, lnStart, col, sp, acc) = state
+          val state = LS
+            (dbgState, ct, cats, Seq.empty (), lnStart, col, sp, acc)
+
+          val comsDoc = concatDocs
+            (Seq.map (at Tab.root o tokenToDocWithBlankLines Tab.root) coms)
+        in
+          layout VarDict.empty state comsDoc
+        end
+
+
       val initComments =
         case firstToken doc of
           NONE => Seq.empty ()
@@ -1315,7 +1331,8 @@ struct
         , []
         )
       val init = dbgBreak Tab.root (dbgInsert Tab.root init)
-      val LS (_, _, _, _, _, _, _, items) = layout VarDict.empty init doc
+      val LS (_, _, _, _, _, _, _, items) = flushComments
+        (layout VarDict.empty init doc)
       val items =
         if not debug then items
         else Item.EndDebug (EndTabHighlight {tab = Tab.root, col = 0}) :: items

--- a/src/prettier-print/TabbedTokenDoc.sml
+++ b/src/prettier-print/TabbedTokenDoc.sml
@@ -57,16 +57,15 @@ local
     val allCommentsBefore = Token.commentsBefore
     val allCommentsAfter = Token.commentsAfter
 
-    (* Find index i where the first i comments belong to tok1, and the
-     * rest belong to tok2.
-     * (tok1, comments, tok2) must be adjacent.
+    (* Find index i where the first i comments should belong to tok, and the
+     * rest belong to the next token. (tok, comments) must be adjacent.
      *)
-    fun findSplit (tok1, comments, _) =
+    fun findSplit (tok, comments) =
       let
         val n = Seq.length comments
         fun loop i =
           if i >= n then n
-          else if Token.lineDifference (tok1, Seq.nth comments i) > 0 then i
+          else if Token.lineDifference (tok, Seq.nth comments i) > 0 then i
           else loop (i + 1)
       in
         loop 0
@@ -78,34 +77,25 @@ local
       | SOME ptok =>
           let
             val cs = allCommentsBefore tok
-            val cs = Seq.drop cs (findSplit (ptok, cs, tok))
-          in
-            cs
-          end
-
-    fun splitCommentsAfter tok =
-      case Token.nextTokenNotCommentOrWhitespace tok of
-        NONE => allCommentsAfter tok
-      | SOME ntok =>
-          let
-            val cs = allCommentsAfter tok
-            val cs = Seq.take cs (findSplit (tok, cs, ntok))
+            val cs = Seq.drop cs (findSplit (ptok, cs))
           in
             cs
           end
 
     fun splitCommentsAfterAndBeforeNext tok =
-      case Token.nextTokenNotCommentOrWhitespace tok of
-        NONE => (allCommentsAfter tok, Seq.empty ())
-      | SOME ntok =>
-          let
-            val cs = allCommentsAfter tok
-            val i = findSplit (tok, cs, ntok)
-            val cs1 = Seq.take cs i
-            val cs2 = Seq.drop cs i
-          in
-            (cs1, cs2)
-          end
+      let
+        val cs = allCommentsAfter tok
+        val i = findSplit (tok, cs)
+        val cs1 = Seq.take cs i
+        val cs2 = Seq.drop cs i
+      in
+        (cs1, cs2)
+      end
+
+    fun splitCommentsAfter tok =
+      let val (cs, _) = splitCommentsAfterAndBeforeNext tok
+      in cs
+      end
   end
 
   datatype pieces =

--- a/test/fmt/comments-at-end.sml
+++ b/test/fmt/comments-at-end.sml
@@ -1,0 +1,6 @@
+val _ = print "hello world\n" (* keep me *)
+(*
+val _ = print "this line is commented out\n"
+*)
+
+(* hello *)


### PR DESCRIPTION
Fixes #89.

Previously, any comments at the end of a file were considered to belong to the last seen non-comment token, and therefore were being laid out "after" this token, resulting in bad layouts. This patch fixes the issue by separately considering comments split off of the last token, and "flushing" these comments onto the root tab.

For example, on the file:
```sml
val _ = print "hello world\n"
(*
val _ = print "this line is commented out\n"
*)
```

Before, `smlfmt` would produce this, which is clearly not great:
```sml
val _ =
  print
    "hello world\n" (*
                    val _ = print "this line is commented out\n"
                    *)
```

After this patch, the output is now preserved:
```sml
val _ = print "hello world\n"
(*
val _ = print "this line is commented out\n"
*)
```

I've checked a full run of `./smlfmt --force src/smlfmt.mlb`: no changes to the formatting of any existing source code in this repo.